### PR TITLE
Manifest-icon-like metadata artworks.

### DIFF
--- a/mediasession.bs
+++ b/mediasession.bs
@@ -132,6 +132,9 @@ urlPrefix: http://www.w3.org/TR/page-visibility/; spec: PAGE-VISIBILITY
     type: enum; urlPrefix: #pv-page-
         text: visible
         text: hidden
+urlPrefix: http://www.w3.org/TR/appmanifest/; spec: appmanifest
+    type: dfn
+        text: image object; url: #dfn-image-object
 urlPrefix: https://heycam.github.io/webidl/
     type: exception
         text: InvalidStateError
@@ -289,8 +292,18 @@ attribute must return the <a>media session</a>'s <a>kind</a>.
 
 The <dfn attribute for="MediaSession"><code>metadata</code></dfn> attribute, on
 getting, must return the <a>media session</a>'s <a lt="media session
-metadata">metadata</a>. On setting, the <a>media session</a>'s <a lt="media
-session metadata">metadata</a> must be set to the new value.
+metadata">metadata</a>. On setting, the user agent must run the following steps:
+
+<ol>
+  <li>
+    Set the <a>media session</a>'s <a lt="media session metadata">metadata</a>
+    to the new value.
+  </li>
+  <li>
+    Run the <a>fetch steps</a> for <a>media session</a>'s <a lt="media session
+    metadata">metadata</a>.
+  </li>
+</ol>
 
 The <dfn method for="MediaSession"><code>activate()</code></dfn> method, when
 invoked, must run these steps:
@@ -1123,14 +1136,20 @@ interface MediaMetadata {
   readonly attribute DOMString title;
   readonly attribute DOMString artist;
   readonly attribute DOMString album;
+  readonly attribute sequence&lt;MediaArtwork> artworks;
 };
 
 dictionary MediaMetadataInit {
   DOMString title = "";
   DOMString artist = "";
   DOMString album = "";
+  sequence&lt;MediaArtworkInit>? artworks;
 };
 </pre>
+
+A {{MediaMetadata}} object has a <dfn for="MediaMetadata">title</dfn>, an <dfn
+for="MediaMetadata">artist</dfn>, an <dfn for="MediaMetadata">album</dfn> and a
+sequence of <dfn for="MediaMetadata">artwork</dfn>s.
 
 The <dfn constructor
 for="MediaMetadata"><code>MediaMetadata(<var>init</var>)</code></dfn>
@@ -1141,15 +1160,148 @@ constructor, when invoked, must run the following steps:
     Let <var>metadata</var> be a new {{MediaMetadata}} object.
   </li>
   <li>
-    Set <var>metadata</var>'s {{MediaMetadata/title}}, {{MediaMetadata/artist}},
-    and {{MediaMetadata/album}} attributes to the values of <var>init</var>'s
-    {{MediaMetadataInit/title}}, {{MediaMetadataInit/artist}}, and
-    {{MediaMetadataInit/album}} members, respectively.
+    Set <var>metadata</var>'s {{MediaMetadata/title}} to <var>init</var>'s
+    {{MediaMetadataInit/title}}.
+  </li>
+  <li>
+    Set <var>metadata</var>'s {{MediaMetadata/artist}} to <var>init</var>'s
+    {{MediaMetadataInit/artist}}.
+  </li>
+  <li>
+    Set <var>metadata</var>'s {{MediaMetadata/album}} to
+    <var>init</var>'s {{MediaMetadataInit/album}}.
+  </li>
+  <li>
+    Set <var>metadata</var>'s {{MediaMetadata/artworks}} using <var>init</var>'s
+    {{MediaMetadataInit/artworks}} by calling the
+    <a><code>MediaArtwork(init)</code></a> constructor.
   </li>
   <li>
     Return <var>metadata</var>.
   </li>
 </ol>
+
+The <dfn attribute for="MediaMetadata"><code>title</code></dfn> attribute must
+return the {{MediaMetadata}} objects's <a>title</a>.
+
+The <dfn attribute for="MediaMetadata"><code>artist</code></dfn> attribute must
+return the {{MediaMetadata}} objects's <a>artist</a>.
+
+The <dfn attribute for="MediaMetadata"><code>album</code></dfn> attribute must
+return the {{MediaMetadata}} objects's <a>album</a>.
+
+The <dfn attribute for="MediaMetadata"><code>artworks</code></dfn> attribute
+must return the {{MediaMetadata}} objects's <a>artwork</a>s, as a sequence of
+{{MediaArtwork}}s. The <a attribute for="MediaMetadata">artworks</a> attribute
+can be empty.
+
+The <dfn>fetch steps</dfn> for a given {{MediaMetadata}} object
+<var>metadata</var> are:
+
+<ol>
+  <!-- XXX https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055 -->
+  <li>
+    If <var>metadata</var>'s <a><code>artworks</code></a> is empty, then
+    terminate these steps.
+  </li>
+  <li>
+    If the platform supports displaying media artwork, select a <dfn>prefered
+    artwork</dfn>
+    from <var>metadata</var>'s <a><code>artworks</code></a>.
+  </li>
+  <li>
+    <a lt="fetch">Fetch</a> <a>prefered artwork</a>'s {{MediaArtwork/src}}.
+
+    Then, <a>in parallel</a>:
+
+    <ol>
+      <li>
+        Wait for the <a>response</a>.
+      </li>
+      <li>
+        If the <a>response</a>'s <a>internal response</a>'s
+        <a lt="response type">type</a> is <i>default</i>, attempt to decode the
+        resource as image.
+      </li>
+      <li>
+        If the image format is supported, use the image as the artwork for
+        display. (Otherwise the user agent can select another <a>prefered
+        artwork</a> and try again.)
+      </li>
+    </ol>
+  </li>
+</ol>
+
+<h2 id="the-mediaartwork-interface">The {{MediaArtwork}} interface</h2>
+
+<pre class="idl">
+
+[Constructor(MediaArtworkInit init)]
+interface MediaArtwork {
+  readonly attribute DOMString src;
+  readonly attribute DOMString sizes;
+  readonly attribute DOMString type;
+};
+
+dictionary MediaArtworkInit {
+  DOMString src = "";
+  DOMString sizes = "";
+  DOMString type = "";
+};
+</pre>
+
+A {{MediaArtwork}} object has a <dfn for="MediaArtwork">source</dfn>, a list of
+<dfn for="MediaArtwork">sizes</dfn>, and a <dfn for="MediaArtwork">type</dfn>.
+
+The <dfn constructor
+for="MediaArtwork"><code>MediaMetadata(<var>init</var>)</code></dfn>
+constructor, when invoked, must run the following steps:
+
+<ol>
+  <li>
+    Let <var>metadata</var> be a new {{MediaArtwork}} object.
+  </li>
+  <li>
+    Set <var>metadata</var>'s {{MediaArtwork/src}} to <var>init</var>'s
+    {{MediaArtworkInit/src}}.
+  </li>
+  <li>
+    Set <var>metadata</var>'s {{MediaArtwork/sizes}} to <var>init</var>'s
+    {{MediaArtworkInit/sizes}}.
+  </li>
+  <li>
+    Set <var>metadata</var>'s {{MediaArtwork/type}} to <var>init</var>'s
+    {{MediaArtworkInit/type}}.
+  </li>
+  <li>
+    Return <var>metadata</var>.
+  </li>
+</ol>
+
+
+The MediaArtwork <a attribute for="MediaArtwork">src</a>, <a attribute
+for="MediaArtwork">sizes</a> and <a attribute for="MediaArtwork">type</a>
+conforms to the <a>image object</a>s in Web App Manifest.
+
+The <dfn attribute for="MediaArtwork">src</dfn> attribute must return the
+{{MediaArtwork}} object's <a for="MediaArtwork">source</a>. It is a URL from
+which the user agent can fetch the image's data.
+
+The <dfn attribute for="MediaArtwork">sizes</dfn> attribute must return the
+{{MediaArtwork}} object's <a for="MediaArtwork">sizes</a>. It is a string
+consisting of an unordered set of unique space-separated tokens which are AScII
+case insensitive that represents the dimensions of an image. Each keyword is
+either an ASCII case-insensitive match for the string "any", or a value that
+consists of two valid non-negative integers that do not have a leading U+0030
+DIGIT ZERO (0) character and that are separated by a single U+0078 LATIN SMALL
+LETTER X or U+0058 LATIN CAPITAL LETTER X character. The keywords represent icon
+sizes in raw pixels (as opposed to CSS pixels). When multiple image objects are
+available, a user agent may use the value to decide which icon is most suitable
+for a display context (and ignore any that are inappropriate).
+
+The <dfn attribute for="MediaArtwork">type</dfn> attribute must return the
+{{MediaArtwork}} object's <a for="MediaArtwork">type</a>. It is a MIME type for
+deciding the media type of the image.
 
 <h2 id="extensions-to-the-htmlmediaelement-interface">Extensions to the
 {{HTMLMediaElement}} interface</h2>
@@ -1353,6 +1505,9 @@ When the user agent is to <dfn>resume a web audio object</dfn> for a given
       title: "Episode Title",
       artist: "Podcast Host",
       album: "Podcast Title",
+      artworks: {
+        src:"podcast.jpg"
+      }
     });
   </pre>
 </div>
@@ -1386,6 +1541,9 @@ When the user agent is to <dfn>resume a web audio object</dfn> for a given
         title: event.target == audio1 ? "Chapter 1" : "Chapter 2",
         artist: "An Author",
         album: "A Book",
+        artworks: {
+          src: "cover.jpg"
+        }
       });
     }
 

--- a/mediasession.bs
+++ b/mediasession.bs
@@ -1136,20 +1136,20 @@ interface MediaMetadata {
   readonly attribute DOMString title;
   readonly attribute DOMString artist;
   readonly attribute DOMString album;
-  readonly attribute sequence&lt;MediaArtwork> artworks;
+  readonly attribute FrozenArray&lt;MediaArtwork> artworks;
 };
 
 dictionary MediaMetadataInit {
   DOMString title = "";
   DOMString artist = "";
   DOMString album = "";
-  sequence&lt;MediaArtworkInit>? artworks;
+  sequence&lt;MediaArtworkInit> artworks = [];
 };
 </pre>
 
 A {{MediaMetadata}} object has a <dfn for="MediaMetadata">title</dfn>, an <dfn
 for="MediaMetadata">artist</dfn>, an <dfn for="MediaMetadata">album</dfn> and a
-sequence of <dfn for="MediaMetadata">artwork</dfn>s.
+FrozenArray of <dfn for="MediaMetadata" title="artwork">artworks</dfn>.
 
 The <dfn constructor
 for="MediaMetadata"><code>MediaMetadata(<var>init</var>)</code></dfn>
@@ -1210,7 +1210,7 @@ The <dfn>fetch steps</dfn> for a given {{MediaMetadata}} object
     from <var>metadata</var>'s <a><code>artworks</code></a>.
   </li>
   <li>
-    <a lt="fetch">Fetch</a> <a>prefered artwork</a>'s {{MediaArtwork/src}}.
+    <a title="fetch">Fetch</a> <a>prefered artwork</a>'s {{MediaArtwork/src}}.
 
     Then, <a>in parallel</a>:
 
@@ -1281,7 +1281,7 @@ constructor, when invoked, must run the following steps:
 
 The MediaArtwork <a attribute for="MediaArtwork">src</a>, <a attribute
 for="MediaArtwork">sizes</a> and <a attribute for="MediaArtwork">type</a>
-conforms to the <a>image object</a>s in Web App Manifest.
+inspired from the <a>image object</a>s in Web App Manifest.
 
 The <dfn attribute for="MediaArtwork">src</dfn> attribute must return the
 {{MediaArtwork}} object's <a for="MediaArtwork">source</a>. It is a URL from
@@ -1300,8 +1300,9 @@ available, a user agent may use the value to decide which icon is most suitable
 for a display context (and ignore any that are inappropriate).
 
 The <dfn attribute for="MediaArtwork">type</dfn> attribute must return the
-{{MediaArtwork}} object's <a for="MediaArtwork">type</a>. It is a MIME type for
-deciding the media type of the image.
+{{MediaArtwork}} object's <a for="MediaArtwork">type</a>. It is a hint as to the
+media type of the image. The purpose of attribute is to allow a user agent to
+ignore images of media types it does not support.
 
 <h2 id="extensions-to-the-htmlmediaelement-interface">Extensions to the
 {{HTMLMediaElement}} interface</h2>
@@ -1505,11 +1506,36 @@ When the user agent is to <dfn>resume a web audio object</dfn> for a given
       title: "Episode Title",
       artist: "Podcast Host",
       album: "Podcast Title",
-      artworks: {
-        src:"podcast.jpg"
-      }
+      artworks: [{src: "podcast.jpg"}]
     });
   </pre>
+
+  Alternatively, providing multiple artworks in the metadata can let the user
+  agent be able to select different artworks for different display purposes:
+
+  <pre class="lang-javascript">
+    audio.session.metadata = new MediaMetadata({
+      title: "Episode Title",
+      artist: "Podcast Host",
+      album: "Podcast Title",
+      artworks: [
+        {src: "podcast.jpg", sizes: "128x128", type: "image/jpeg"},
+        {src: "podcast_hd.jpg", sizes: "256x256"},
+        {src: "podcast_xhd.jpg", sizes: "1024x1024", type: "image/jpeg"},
+        {src: "podcast.png", sizes: "128x128", type: "image/png"},
+        {src: "podcast_hd.png", sizes: "256x256", type: "image/png"},
+        {src: "podcast.ico", sizes: "128x128 256x256", type: "image/x-icon"}
+      ]
+    });
+  </pre>
+
+  For example, if the user agent wants to use an image as icon, it may choose
+  <code>"podcast.jpg"</code> or <code>"podcast.png"</code> for a
+  low-pixel-density screen, and <code>"podcast_hd.jpg"</code>
+  or <code>"podcast_hd.png"</code> for a high-pixel-density screen. If the user
+  agent want to use an image for lockscreen background,
+  <code>"podcast_xhd.jpg"</code> will be prefered.
+
 </div>
 
 <div class="example">
@@ -1541,9 +1567,7 @@ When the user agent is to <dfn>resume a web audio object</dfn> for a given
         title: event.target == audio1 ? "Chapter 1" : "Chapter 2",
         artist: "An Author",
         album: "A Book",
-        artworks: {
-          src: "cover.jpg"
-        }
+        artworks: [{src: "cover.jpg"}]
       });
     }
 

--- a/mediasession.bs
+++ b/mediasession.bs
@@ -41,10 +41,13 @@ urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML
     type: dfn
         urlPrefix: infrastructure.html
             text: case-sensitive; url: #case-sensitivity-and-string-comparison
+            text: ASCII case-insensitive; url: #ascii-case-insensitive
             text: reflect
             text: limited to only known values
             text: remove an element from a document; url: #remove-an-element-from-a-document
             text: in parallel
+            text: unordered set of unique space-separated tokens; url: #unordered-set-of-unique-space-separated-tokens
+            text: document base url
         urlPrefix: embedded-content.html
             text: media element
             text: media element load algorithm
@@ -67,6 +70,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML
             text: task
             text: task source
             text: DOM manipulation task source
+        urlPrefix: semantics.html
+            text: link; for: HTMLLinkElement; url:#the-link-element
     type: method
         urlPrefix: embedded-content.html
             text: play(); for: HTMLMediaElement; url: #dom-media-play
@@ -81,6 +86,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML
             text: networkState; for: HTMLMediaElement; url: #dom-media-networkstate
             text: NETWORK_LOADING; for: HTMLMediaElement; url: #dom-media-network_loading
             text: NETWORK_IDLE; for: HTMLMediaElement; url: #dom-media-network_idle
+        urlPrefix: semantics.html
+            text: sizes; for: HTMLLinkElement; url: #attr-link-sizes;
     type: event
         urlPrefix: embedded-content.html
             text: pause; url: #event-media-pause
@@ -89,6 +96,9 @@ urlPrefix: https://url.spec.whatwg.org/;
     type: dfn; urlPrefix: #concept-
         text: url parser
         text: event listener
+    type: dfn
+        text: absolute URL; url: #syntax-url-absolute
+        text: relative URL; url: #syntax-url-relative
 urlPrefix: https://fetch.spec.whatwg.org/; spec: FETCH
     type: dfn; urlPrefix: #concept-
         text: fetch
@@ -132,7 +142,7 @@ urlPrefix: http://www.w3.org/TR/page-visibility/; spec: PAGE-VISIBILITY
     type: enum; urlPrefix: #pv-page-
         text: visible
         text: hidden
-urlPrefix: http://www.w3.org/TR/appmanifest/; spec: appmanifest
+urlPrefix: https://www.w3.org/TR/appmanifest/; spec: appmanifest
     type: dfn
         text: image object; url: #dfn-image-object
 urlPrefix: https://heycam.github.io/webidl/
@@ -292,18 +302,7 @@ attribute must return the <a>media session</a>'s <a>kind</a>.
 
 The <dfn attribute for="MediaSession"><code>metadata</code></dfn> attribute, on
 getting, must return the <a>media session</a>'s <a lt="media session
-metadata">metadata</a>. On setting, the user agent must run the following steps:
-
-<ol>
-  <li>
-    Set the <a>media session</a>'s <a lt="media session metadata">metadata</a>
-    to the new value.
-  </li>
-  <li>
-    Run the <a>fetch steps</a> for <a>media session</a>'s <a lt="media session
-    metadata">metadata</a>.
-  </li>
-</ol>
+metadata">metadata</a>.
 
 The <dfn method for="MediaSession"><code>activate()</code></dfn> method, when
 invoked, must run these steps:
@@ -1136,20 +1135,21 @@ interface MediaMetadata {
   readonly attribute DOMString title;
   readonly attribute DOMString artist;
   readonly attribute DOMString album;
-  readonly attribute FrozenArray&lt;MediaArtwork> artworks;
+  [SameObject] readonly attribute FrozenArray&lt;MediaArtwork> artwork;
 };
 
 dictionary MediaMetadataInit {
   DOMString title = "";
   DOMString artist = "";
   DOMString album = "";
-  sequence&lt;MediaArtworkInit> artworks = [];
+  sequence&lt;MediaArtworkInit> artwork = [];
 };
 </pre>
 
 A {{MediaMetadata}} object has a <dfn for="MediaMetadata">title</dfn>, an <dfn
 for="MediaMetadata">artist</dfn>, an <dfn for="MediaMetadata">album</dfn> and a
-FrozenArray of <dfn for="MediaMetadata" title="artwork">artworks</dfn>.
+FrozenArray of <dfn for="MediaMetadata" title="artwork image">artwork
+images</dfn>.
 
 The <dfn constructor
 for="MediaMetadata"><code>MediaMetadata(<var>init</var>)</code></dfn>
@@ -1172,8 +1172,8 @@ constructor, when invoked, must run the following steps:
     <var>init</var>'s {{MediaMetadataInit/album}}.
   </li>
   <li>
-    Set <var>metadata</var>'s {{MediaMetadata/artworks}} using <var>init</var>'s
-    {{MediaMetadataInit/artworks}} by calling the
+    Set <var>metadata</var>'s {{MediaMetadata/artwork}} using <var>init</var>'s
+    {{MediaMetadataInit/artwork}} by calling the
     <a><code>MediaArtwork(init)</code></a> constructor.
   </li>
   <li>
@@ -1190,27 +1190,31 @@ return the {{MediaMetadata}} objects's <a>artist</a>.
 The <dfn attribute for="MediaMetadata"><code>album</code></dfn> attribute must
 return the {{MediaMetadata}} objects's <a>album</a>.
 
-The <dfn attribute for="MediaMetadata"><code>artworks</code></dfn> attribute
-must return the {{MediaMetadata}} objects's <a>artwork</a>s, as a sequence of
-{{MediaArtwork}}s. The <a attribute for="MediaMetadata">artworks</a> attribute
-can be empty.
+The <dfn attribute for="MediaMetadata"><code>artwork</code></dfn>
+attribute must return the {{MediaMetadata}} objects's <a for="MediaMetadata"
+title="artwork image">artwork images</a>, as a FrozenArray of {{MediaArtwork}}s.
+The <a attribute for="MediaMetadata">artwork</a> attribute can be empty.
 
-The <dfn>fetch steps</dfn> for a given {{MediaMetadata}} object
-<var>metadata</var> are:
+When the user agent wants to display the {{MediaSession}}'s artwork
+as specified in it's <var>metadata</var>, it is recommended to run the
+following <dfn>fetch steps</dfn>:
 
 <ol>
   <!-- XXX https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055 -->
   <li>
-    If <var>metadata</var>'s <a><code>artworks</code></a> is empty, then
-    terminate these steps.
+    If <var>metadata</var>'s <a attribute
+    for="MediaMetadata"><code>artwork</code></a> is empty, then terminate these
+    steps.
   </li>
   <li>
     If the platform supports displaying media artwork, select a <dfn>prefered
-    artwork</dfn>
-    from <var>metadata</var>'s <a><code>artworks</code></a>.
+    artwork image</dfn>
+    from <var>metadata</var>'s <a attribute
+    for="MediaMetadata"><code>artwork</code></a>.
   </li>
   <li>
-    <a title="fetch">Fetch</a> <a>prefered artwork</a>'s {{MediaArtwork/src}}.
+    <a title="fetch">Fetch</a> <a>prefered artwork image</a>'s
+    {{MediaArtwork/src}}.
 
     Then, <a>in parallel</a>:
 
@@ -1224,9 +1228,9 @@ The <dfn>fetch steps</dfn> for a given {{MediaMetadata}} object
         resource as image.
       </li>
       <li>
-        If the image format is supported, use the image as the artwork for
-        display. (Otherwise the user agent can select another <a>prefered
-        artwork</a> and try again.)
+        If the image format is supported, use the image as the artwork
+        for display. (Otherwise the fetch step fails and the user
+        agent may take fallback actions.)
       </li>
     </ol>
   </li>
@@ -1238,13 +1242,13 @@ The <dfn>fetch steps</dfn> for a given {{MediaMetadata}} object
 
 [Constructor(MediaArtworkInit init)]
 interface MediaArtwork {
-  readonly attribute DOMString src;
+  readonly attribute USVString src;
   readonly attribute DOMString sizes;
   readonly attribute DOMString type;
 };
 
 dictionary MediaArtworkInit {
-  DOMString src = "";
+  USVString src = "";
   DOMString sizes = "";
   DOMString type = "";
 };
@@ -1254,7 +1258,7 @@ A {{MediaArtwork}} object has a <dfn for="MediaArtwork">source</dfn>, a list of
 <dfn for="MediaArtwork">sizes</dfn>, and a <dfn for="MediaArtwork">type</dfn>.
 
 The <dfn constructor
-for="MediaArtwork"><code>MediaMetadata(<var>init</var>)</code></dfn>
+for="MediaArtwork"><code>MediaArtwork(<var>init</var>)</code></dfn>
 constructor, when invoked, must run the following steps:
 
 <ol>
@@ -1262,8 +1266,10 @@ constructor, when invoked, must run the following steps:
     Let <var>metadata</var> be a new {{MediaArtwork}} object.
   </li>
   <li>
-    Set <var>metadata</var>'s {{MediaArtwork/src}} to <var>init</var>'s
-    {{MediaArtworkInit/src}}.
+    Set <var>metadata</var>'s {{MediaArtwork/src}}
+    to <var>init</var>'s {{MediaArtworkInit/src}}. If the URL is a
+    <a>relative URL</a>, it must be resolved to an <a>absolute URL</a> using
+    the <a>document base URL</a>.
   </li>
   <li>
     Set <var>metadata</var>'s {{MediaArtwork/sizes}} to <var>init</var>'s
@@ -1288,16 +1294,23 @@ The <dfn attribute for="MediaArtwork">src</dfn> attribute must return the
 which the user agent can fetch the image's data.
 
 The <dfn attribute for="MediaArtwork">sizes</dfn> attribute must return the
-{{MediaArtwork}} object's <a for="MediaArtwork">sizes</a>. It is a string
-consisting of an unordered set of unique space-separated tokens which are AScII
-case insensitive that represents the dimensions of an image. Each keyword is
-either an ASCII case-insensitive match for the string "any", or a value that
-consists of two valid non-negative integers that do not have a leading U+0030
-DIGIT ZERO (0) character and that are separated by a single U+0078 LATIN SMALL
-LETTER X or U+0058 LATIN CAPITAL LETTER X character. The keywords represent icon
-sizes in raw pixels (as opposed to CSS pixels). When multiple image objects are
-available, a user agent may use the value to decide which icon is most suitable
-for a display context (and ignore any that are inappropriate).
+{{MediaArtwork}} object's <a for="MediaArtwork">sizes</a>. It follows the spec
+of <a attribute for="HTMLLinkElement"><code>sizes</code></a> attribute in HTML
+<a for="HTMLLinkElement"><code>link</code></a> element, which is a
+string consisting of an <a>unordered set of unique space-separated
+tokens</a> which are <a>ASCII case-insensitive</a> that represents the
+dimensions of an image. Each keyword is either an <a>ASCII
+case-insensitive</a> match for the string "any", or a value that
+consists of two valid non-negative integers that do not have a leading
+U+0030 DIGIT ZERO (0) character and that are separated by a single
+U+0078 LATIN SMALL LETTER X or U+0058 LATIN CAPITAL LETTER X
+character. The keywords represent icon sizes in raw pixels (as opposed
+to CSS pixels). When multiple image objects are available, a user
+agent may use the value to decide which icon is most suitable for a
+display context (and ignore any that are inappropriate). The parsing
+steps for the <a attribute for="MediaArtwork">sizes</a> attribute must
+follow <a attribute for="HTMLLinkElement" lt="sizes">the parsing steps
+for HTML <code>link</code> element <code>sizes</code> attribute</a>.
 
 The <dfn attribute for="MediaArtwork">type</dfn> attribute must return the
 {{MediaArtwork}} object's <a for="MediaArtwork">type</a>. It is a hint as to the
@@ -1506,19 +1519,21 @@ When the user agent is to <dfn>resume a web audio object</dfn> for a given
       title: "Episode Title",
       artist: "Podcast Host",
       album: "Podcast Title",
-      artworks: [{src: "podcast.jpg"}]
+      artwork: [{src: "podcast.jpg"}]
     });
   </pre>
 
-  Alternatively, providing multiple artworks in the metadata can let the user
-  agent be able to select different artworks for different display purposes:
+  Alternatively, providing multiple <a for="MediaMetadata" title="artwork
+  image">artwork images</a> in the metadata can let the user agent be able to
+  select different artwork images for different display purposes and better fit
+  for different screens:
 
   <pre class="lang-javascript">
     audio.session.metadata = new MediaMetadata({
       title: "Episode Title",
       artist: "Podcast Host",
       album: "Podcast Title",
-      artworks: [
+      artwork: [
         {src: "podcast.jpg", sizes: "128x128", type: "image/jpeg"},
         {src: "podcast_hd.jpg", sizes: "256x256"},
         {src: "podcast_xhd.jpg", sizes: "1024x1024", type: "image/jpeg"},
@@ -1567,7 +1582,7 @@ When the user agent is to <dfn>resume a web audio object</dfn> for a given
         title: event.target == audio1 ? "Chapter 1" : "Chapter 2",
         artist: "An Author",
         album: "A Book",
-        artworks: [{src: "cover.jpg"}]
+        artwork: [{src: "cover.jpg"}]
       });
     }
 

--- a/mediasession.bs
+++ b/mediasession.bs
@@ -92,7 +92,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML
         urlPrefix: embedded-content.html
             text: pause; url: #event-media-pause
             text: play; url: #event-media-play
-urlPrefix: https://url.spec.whatwg.org/;
+urlPrefix: https://url.spec.whatwg.org/; spec: URL
     type: dfn; urlPrefix: #concept-
         text: url parser
         text: event listener
@@ -1135,14 +1135,14 @@ interface MediaMetadata {
   readonly attribute DOMString title;
   readonly attribute DOMString artist;
   readonly attribute DOMString album;
-  [SameObject] readonly attribute FrozenArray&lt;MediaArtwork> artwork;
+  [SameObject] readonly attribute FrozenArray&lt;MediaImage> artwork;
 };
 
 dictionary MediaMetadataInit {
   DOMString title = "";
   DOMString artist = "";
   DOMString album = "";
-  sequence&lt;MediaArtworkInit> artwork = [];
+  sequence&lt;MediaImageInit> artwork = [];
 };
 </pre>
 
@@ -1174,7 +1174,7 @@ constructor, when invoked, must run the following steps:
   <li>
     Set <var>metadata</var>'s {{MediaMetadata/artwork}} using <var>init</var>'s
     {{MediaMetadataInit/artwork}} by calling the
-    <a><code>MediaArtwork(init)</code></a> constructor.
+    <a><code>MediaImage(init)</code></a> constructor.
   </li>
   <li>
     Return <var>metadata</var>.
@@ -1192,12 +1192,12 @@ return the {{MediaMetadata}} objects's <a>album</a>.
 
 The <dfn attribute for="MediaMetadata"><code>artwork</code></dfn>
 attribute must return the {{MediaMetadata}} objects's <a for="MediaMetadata"
-title="artwork image">artwork images</a>, as a FrozenArray of {{MediaArtwork}}s.
+title="artwork image">artwork images</a>, as a FrozenArray of {{MediaImage}}s.
 The <a attribute for="MediaMetadata">artwork</a> attribute can be empty.
 
-When the user agent wants to display the {{MediaSession}}'s artwork
-as specified in it's <var>metadata</var>, it is recommended to run the
-following <dfn>fetch steps</dfn>:
+When a user agent wants to display the {{MediaSession}}'s artwork as specified
+in it's <var>metadata</var>, it is recommended to run the following <dfn>fetch
+steps</dfn>:
 
 <ol>
   <!-- XXX https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055 -->
@@ -1214,7 +1214,7 @@ following <dfn>fetch steps</dfn>:
   </li>
   <li>
     <a title="fetch">Fetch</a> <a>prefered artwork image</a>'s
-    {{MediaArtwork/src}}.
+    {{MediaImage/src}}.
 
     Then, <a>in parallel</a>:
 
@@ -1228,56 +1228,58 @@ following <dfn>fetch steps</dfn>:
         resource as image.
       </li>
       <li>
-        If the image format is supported, use the image as the artwork
-        for display. (Otherwise the fetch step fails and the user
-        agent may take fallback actions.)
+        If the image format is supported, use the image as the artwork for
+        display. Otherwise the <a>fetch steps</a> fail and terminate.
       </li>
     </ol>
   </li>
 </ol>
 
-<h2 id="the-mediaartwork-interface">The {{MediaArtwork}} interface</h2>
+If no artwork images are fetched in the <a>fetch steps</a>, the user agent may
+have fallback behavior such as displaying an default image as artwork.
+
+<h2 id="the-mediaimage-interface">The {{MediaImage}} interface</h2>
 
 <pre class="idl">
 
-[Constructor(MediaArtworkInit init)]
-interface MediaArtwork {
+[Constructor(MediaImageInit init)]
+interface MediaImage {
   readonly attribute USVString src;
   readonly attribute DOMString sizes;
   readonly attribute DOMString type;
 };
 
-dictionary MediaArtworkInit {
+dictionary MediaImageInit {
   USVString src = "";
   DOMString sizes = "";
   DOMString type = "";
 };
 </pre>
 
-A {{MediaArtwork}} object has a <dfn for="MediaArtwork">source</dfn>, a list of
-<dfn for="MediaArtwork">sizes</dfn>, and a <dfn for="MediaArtwork">type</dfn>.
+A {{MediaImage}} object has a <dfn for="MediaImage">source</dfn>, a list of
+<dfn for="MediaImage">sizes</dfn>, and a <dfn for="MediaImage">type</dfn>.
 
 The <dfn constructor
-for="MediaArtwork"><code>MediaArtwork(<var>init</var>)</code></dfn>
+for="MediaImage"><code>MediaImage(<var>init</var>)</code></dfn>
 constructor, when invoked, must run the following steps:
 
 <ol>
   <li>
-    Let <var>metadata</var> be a new {{MediaArtwork}} object.
+    Let <var>metadata</var> be a new {{MediaImage}} object.
   </li>
   <li>
-    Set <var>metadata</var>'s {{MediaArtwork/src}}
-    to <var>init</var>'s {{MediaArtworkInit/src}}. If the URL is a
-    <a>relative URL</a>, it must be resolved to an <a>absolute URL</a> using
-    the <a>document base URL</a>.
+    Set <var>metadata</var>'s {{MediaImage/src}} to <var>init</var>'s
+    {{MediaImageInit/src}}. If the URL is a
+    <a>relative URL</a>, it must be resolved to an <a>absolute URL</a> using the
+    <a>document base URL</a>.
   </li>
   <li>
-    Set <var>metadata</var>'s {{MediaArtwork/sizes}} to <var>init</var>'s
-    {{MediaArtworkInit/sizes}}.
+    Set <var>metadata</var>'s {{MediaImage/sizes}} to <var>init</var>'s
+    {{MediaImageInit/sizes}}.
   </li>
   <li>
-    Set <var>metadata</var>'s {{MediaArtwork/type}} to <var>init</var>'s
-    {{MediaArtworkInit/type}}.
+    Set <var>metadata</var>'s {{MediaImage/type}} to <var>init</var>'s
+    {{MediaImageInit/type}}.
   </li>
   <li>
     Return <var>metadata</var>.
@@ -1285,37 +1287,36 @@ constructor, when invoked, must run the following steps:
 </ol>
 
 
-The MediaArtwork <a attribute for="MediaArtwork">src</a>, <a attribute
-for="MediaArtwork">sizes</a> and <a attribute for="MediaArtwork">type</a>
-inspired from the <a>image object</a>s in Web App Manifest.
+The MediaImage <a attribute for="MediaImage">src</a>, <a attribute
+for="MediaImage">sizes</a> and <a attribute for="MediaImage">type</a>
+inspired from the <a lt="image object">image objects</a> in Web App Manifest.
 
-The <dfn attribute for="MediaArtwork">src</dfn> attribute must return the
-{{MediaArtwork}} object's <a for="MediaArtwork">source</a>. It is a URL from
-which the user agent can fetch the image's data.
+The <dfn attribute for="MediaImage">src</dfn> attribute must return the
+{{MediaImage}} object's <a for="MediaImage">source</a>. It is a URL from which
+the user agent can fetch the image's data.
 
-The <dfn attribute for="MediaArtwork">sizes</dfn> attribute must return the
-{{MediaArtwork}} object's <a for="MediaArtwork">sizes</a>. It follows the spec
-of <a attribute for="HTMLLinkElement"><code>sizes</code></a> attribute in HTML
-<a for="HTMLLinkElement"><code>link</code></a> element, which is a
-string consisting of an <a>unordered set of unique space-separated
-tokens</a> which are <a>ASCII case-insensitive</a> that represents the
-dimensions of an image. Each keyword is either an <a>ASCII
-case-insensitive</a> match for the string "any", or a value that
-consists of two valid non-negative integers that do not have a leading
-U+0030 DIGIT ZERO (0) character and that are separated by a single
-U+0078 LATIN SMALL LETTER X or U+0058 LATIN CAPITAL LETTER X
-character. The keywords represent icon sizes in raw pixels (as opposed
-to CSS pixels). When multiple image objects are available, a user
-agent may use the value to decide which icon is most suitable for a
-display context (and ignore any that are inappropriate). The parsing
-steps for the <a attribute for="MediaArtwork">sizes</a> attribute must
-follow <a attribute for="HTMLLinkElement" lt="sizes">the parsing steps
-for HTML <code>link</code> element <code>sizes</code> attribute</a>.
+The <dfn attribute for="MediaImage">sizes</dfn> attribute must return the
+{{MediaImage}} object's <a for="MediaImage">sizes</a>. It follows the spec of <a
+attribute for="HTMLLinkElement"><code>sizes</code></a> attribute in HTML
+<a for="HTMLLinkElement"><code>link</code></a> element, which is a string
+consisting of an <a>unordered set of unique space-separated tokens</a> which are
+<a>ASCII case-insensitive</a> that represents the dimensions of an image. Each
+keyword is either an <a>ASCII case-insensitive</a> match for the string "any",
+or a value that consists of two valid non-negative integers that do not have a
+leading U+0030 DIGIT ZERO (0) character and that are separated by a single
+U+0078 LATIN SMALL LETTER X or U+0058 LATIN CAPITAL LETTER X character. The
+keywords represent icon sizes in raw pixels (as opposed to CSS pixels). When
+multiple image objects are available, a user agent may use the value to decide
+which icon is most suitable for a display context (and ignore any that are
+inappropriate). The parsing steps for the <a attribute
+for="MediaImage">sizes</a> attribute must follow <a attribute
+for="HTMLLinkElement" lt="sizes">the parsing steps for HTML <code>link</code>
+element <code>sizes</code> attribute</a>.
 
-The <dfn attribute for="MediaArtwork">type</dfn> attribute must return the
-{{MediaArtwork}} object's <a for="MediaArtwork">type</a>. It is a hint as to the
-media type of the image. The purpose of attribute is to allow a user agent to
-ignore images of media types it does not support.
+The <dfn attribute for="MediaImage">type</dfn> attribute must return the
+{{MediaImage}} object's <a for="MediaImage">type</a>. It is a hint as to the
+media type of the image. The purpose of this attribute is to allow a user agent
+to ignore images of media types it does not support.
 
 <h2 id="extensions-to-the-htmlmediaelement-interface">Extensions to the
 {{HTMLMediaElement}} interface</h2>

--- a/mediasession.html
+++ b/mediasession.html
@@ -225,7 +225,7 @@
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-mediasession.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref" id="title">Media Session</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-06-02">2 June 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-06-08">8 June 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -396,11 +396,7 @@ which is either a <code class="idl"><a data-link-type="idl" href="#mediametadata
    <p>The <dfn class="idl-code" data-dfn-for="MediaSession" data-dfn-type="constructor" data-export="" id="dom-mediasession-mediasession"><code>MediaSession(<var>kind</var>)</code><a class="self-link" href="#dom-mediasession-mediasession"></a></dfn> constructor, when invoked, must return a new <a data-link-type="dfn" href="#media-session">media session</a> whose <a data-link-type="dfn" href="#mediasession-kind">kind</a> is <var>kind</var>, and <a data-link-type="dfn" href="#mediasession-state">state</a> is <code><a data-link-type="dfn" href="#idle-media-session-state">idle</a></code>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MediaSession" data-dfn-type="attribute" data-export="" id="dom-mediasession-kind"><code>kind</code><a class="self-link" href="#dom-mediasession-kind"></a></dfn> attribute must return the <a data-link-type="dfn" href="#media-session">media session</a>’s <a data-link-type="dfn" href="#mediasession-kind">kind</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MediaSession" data-dfn-type="attribute" data-export="" id="dom-mediasession-metadata"><code>metadata</code><a class="self-link" href="#dom-mediasession-metadata"></a></dfn> attribute, on
-getting, must return the <a data-link-type="dfn" href="#media-session">media session</a>’s <a data-link-type="dfn" href="#media-session-metadata">metadata</a>. On setting, the user agent must run the following steps:</p>
-   <ol>
-    <li> Set the <a data-link-type="dfn" href="#media-session">media session</a>’s <a data-link-type="dfn" href="#media-session-metadata">metadata</a> to the new value. 
-    <li> Run the <a data-link-type="dfn" href="#fetch-steps">fetch steps</a> for <a data-link-type="dfn" href="#media-session">media session</a>’s <a data-link-type="dfn" href="#media-session-metadata">metadata</a>. 
-   </ol>
+getting, must return the <a data-link-type="dfn" href="#media-session">media session</a>’s <a data-link-type="dfn" href="#media-session-metadata">metadata</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MediaSession" data-dfn-type="method" data-export="" id="dom-mediasession-activate"><code>activate()</code><a class="self-link" href="#dom-mediasession-activate"></a></dfn> method, when
 invoked, must run these steps:</p>
    <ol>
@@ -817,25 +813,26 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="med
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-title">title</a>;
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-artist">artist</a>;
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-album">album</a>;
-  readonly attribute FrozenArray&lt;<a data-link-type="idl-name" href="#mediaartwork">MediaArtwork</a>> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="FrozenArray<MediaArtwork>" href="#dom-mediametadata-artworks">artworks</a>;
+  [SameObject] readonly attribute FrozenArray&lt;<a data-link-type="idl-name" href="#mediaartwork">MediaArtwork</a>> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="FrozenArray<MediaArtwork>" href="#dom-mediametadata-artwork">artwork</a>;
 };
 
 dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-mediametadatainit">MediaMetadataInit<a class="self-link" href="#dictdef-mediametadatainit"></a></dfn> {
   DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediametadatainit-title">title<a class="self-link" href="#dom-mediametadatainit-title"></a></dfn> = "";
   DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediametadatainit-artist">artist<a class="self-link" href="#dom-mediametadatainit-artist"></a></dfn> = "";
   DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediametadatainit-album">album<a class="self-link" href="#dom-mediametadatainit-album"></a></dfn> = "";
-  sequence&lt;<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a>> <dfn class="idl-code" data-default="None" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MediaArtworkInit> " id="dom-mediametadatainit-artworks">artworks<a class="self-link" href="#dom-mediametadatainit-artworks"></a></dfn> = [];
+  sequence&lt;<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a>> <dfn class="idl-code" data-default="None" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MediaArtworkInit> " id="dom-mediametadatainit-artwork">artwork<a class="self-link" href="#dom-mediametadatainit-artwork"></a></dfn> = [];
 };
 </pre>
    <p>A <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> object has a <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-title">title<a class="self-link" href="#mediametadata-title"></a></dfn>, an <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-artist">artist<a class="self-link" href="#mediametadata-artist"></a></dfn>, an <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-album">album<a class="self-link" href="#mediametadata-album"></a></dfn> and a
-FrozenArray of <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-artworks" title="artwork">artworks<a class="self-link" href="#mediametadata-artworks"></a></dfn>.</p>
+FrozenArray of <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-artwork-images" title="artwork image">artwork
+images<a class="self-link" href="#mediametadata-artwork-images"></a></dfn>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="constructor" data-export="" id="dom-mediametadata-mediametadata"><code>MediaMetadata(<var>init</var>)</code><a class="self-link" href="#dom-mediametadata-mediametadata"></a></dfn> constructor, when invoked, must run the following steps:</p>
    <ol>
     <li> Let <var>metadata</var> be a new <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> object. 
     <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-title">title</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-title">title</a></code>. 
     <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-artist">artist</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-artist">artist</a></code>. 
     <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-album">album</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-album">album</a></code>. 
-    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-artworks">artworks</a></code> using <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-artworks">artworks</a></code> by calling the <a data-link-type="functionish" href="#dom-mediaartwork-mediaartwork"><code>MediaArtwork(init)</code></a> constructor. 
+    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-artwork">artwork</a></code> using <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-artwork">artwork</a></code> by calling the <a data-link-type="functionish" href="#dom-mediaartwork-mediaartwork"><code>MediaArtwork(init)</code></a> constructor. 
     <li> Return <var>metadata</var>. 
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" id="dom-mediametadata-title"><code>title</code><a class="self-link" href="#dom-mediametadata-title"></a></dfn> attribute must
@@ -844,29 +841,30 @@ return the <code class="idl"><a data-link-type="idl" href="#mediametadata">Media
 return the <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> objects’s <a data-link-type="dfn" href="#mediametadata-artist">artist</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" id="dom-mediametadata-album"><code>album</code><a class="self-link" href="#dom-mediametadata-album"></a></dfn> attribute must
 return the <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> objects’s <a data-link-type="dfn" href="#mediametadata-album">album</a>.</p>
-   <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" id="dom-mediametadata-artworks"><code>artworks</code><a class="self-link" href="#dom-mediametadata-artworks"></a></dfn> attribute
-must return the <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> objects’s <a data-link-type="dfn" href="#mediametadata-artworks">artwork</a>s, as a sequence of <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code>s. The <a class="idl-code" data-link-type="attribute" href="#dom-mediametadata-artworks">artworks</a> attribute
-can be empty.</p>
-   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="fetch-steps">fetch steps<a class="self-link" href="#fetch-steps"></a></dfn> for a given <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> object <var>metadata</var> are:</p>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" id="dom-mediametadata-artwork"><code>artwork</code><a class="self-link" href="#dom-mediametadata-artwork"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> objects’s <a data-link-type="dfn" href="#mediametadata-artwork-images" title="artwork image">artwork images</a>, as a FrozenArray of <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code>s.
+The <a class="idl-code" data-link-type="attribute" href="#dom-mediametadata-artwork">artwork</a> attribute can be empty.</p>
+   <p>When the user agent wants to display the <code class="idl"><a data-link-type="idl" href="#mediasession">MediaSession</a></code>'s artwork
+as specified in it’s <var>metadata</var>, it is recommended to run the
+following <dfn data-dfn-type="dfn" data-noexport="" id="fetch-steps">fetch steps<a class="self-link" href="#fetch-steps"></a></dfn>:</p>
    <ol>
-    <li> If <var>metadata</var>’s <a data-link-type="dfn" href="#mediametadata-artworks"><code>artworks</code></a> is empty, then
-    terminate these steps. 
-    <li> If the platform supports displaying media artwork, select a <dfn data-dfn-type="dfn" data-noexport="" id="prefered-artwork">prefered
-    artwork<a class="self-link" href="#prefered-artwork"></a></dfn> from <var>metadata</var>’s <a data-link-type="dfn" href="#mediametadata-artworks"><code>artworks</code></a>. 
+    <li> If <var>metadata</var>’s <a class="idl-code" data-link-type="attribute" href="#dom-mediametadata-artwork"><code>artwork</code></a> is empty, then terminate these
+    steps. 
+    <li> If the platform supports displaying media artwork, select a <dfn data-dfn-type="dfn" data-noexport="" id="prefered-artwork-image">prefered
+    artwork image<a class="self-link" href="#prefered-artwork-image"></a></dfn> from <var>metadata</var>’s <a class="idl-code" data-link-type="attribute" href="#dom-mediametadata-artwork"><code>artwork</code></a>. 
     <li>
-      <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" title="fetch">Fetch</a> <a data-link-type="dfn" href="#prefered-artwork">prefered artwork</a>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-src">src</a></code>. 
+      <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" title="fetch">Fetch</a> <a data-link-type="dfn" href="#prefered-artwork-image">prefered artwork image</a>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-src">src</a></code>. 
      <p>Then, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
      <ol>
       <li> Wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>. 
       <li> If the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-internal-response">internal response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type">type</a> is <i>default</i>, attempt to decode the
         resource as image. 
-      <li> If the image format is supported, use the image as the artwork for
-        display. (Otherwise the user agent can select another <a data-link-type="dfn" href="#prefered-artwork">prefered
-        artwork</a> and try again.) 
+      <li> If the image format is supported, use the image as the artwork
+        for display. (Otherwise the fetch step fails and the user
+        agent may take fallback actions.) 
      </ol>
    </ol>
    <h2 class="heading settled" data-level="6" id="the-mediaartwork-interface"><span class="secno">6. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> interface</span><a class="self-link" href="#the-mediaartwork-interface"></a></h2>
-<pre class="idl def">[<dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="constructor" data-export="" data-lt="MediaArtwork(init)" id="dom-mediaartwork-mediaartwork">Constructor<a class="self-link" href="#dom-mediaartwork-mediaartwork"></a></dfn>(<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a> <dfn class="idl-code" data-dfn-for="MediaArtwork/MediaArtwork(init)" data-dfn-type="argument" data-export="" id="dom-mediaartwork-mediaartwork-init-init">init<a class="self-link" href="#dom-mediaartwork-mediaartwork-init-init"></a></dfn>)]
+<pre class="idl def">[<a class="idl-code" data-link-type="constructor" href="#dom-mediaartwork-mediaartwork">Constructor</a>(<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a> <dfn class="idl-code" data-dfn-for="MediaArtwork/MediaArtwork(init)" data-dfn-type="argument" data-export="" id="dom-mediaartwork-mediaartwork-init-init">init<a class="self-link" href="#dom-mediaartwork-mediaartwork-init-init"></a></dfn>)]
 interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="mediaartwork">MediaArtwork<a class="self-link" href="#mediaartwork"></a></dfn> {
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-src">src</a>;
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-sizes">sizes</a>;
@@ -880,27 +878,34 @@ dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="d
 };
 </pre>
    <p>A <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object has a <dfn data-dfn-for="MediaArtwork" data-dfn-type="dfn" data-noexport="" id="mediaartwork-source">source<a class="self-link" href="#mediaartwork-source"></a></dfn>, a list of <dfn data-dfn-for="MediaArtwork" data-dfn-type="dfn" data-noexport="" id="mediaartwork-sizes">sizes<a class="self-link" href="#mediaartwork-sizes"></a></dfn>, and a <dfn data-dfn-for="MediaArtwork" data-dfn-type="dfn" data-noexport="" id="mediaartwork-type">type<a class="self-link" href="#mediaartwork-type"></a></dfn>.</p>
-   <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="constructor" data-export="" id="dom-mediaartwork-mediametadata"><code>MediaMetadata(<var>init</var>)</code><a class="self-link" href="#dom-mediaartwork-mediametadata"></a></dfn> constructor, when invoked, must run the following steps:</p>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="constructor" data-export="" id="dom-mediaartwork-mediaartwork"><code>MediaArtwork(<var>init</var>)</code><a class="self-link" href="#dom-mediaartwork-mediaartwork"></a></dfn> constructor, when invoked, must run the following steps:</p>
    <ol>
     <li> Let <var>metadata</var> be a new <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object. 
-    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-src">src</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartworkinit-src">src</a></code>. 
+    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-src">src</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartworkinit-src">src</a></code>. If the URL is a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#syntax-url-relative">relative URL</a>, it must be resolved to an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#syntax-url-absolute">absolute URL</a> using
+    the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#document-base-url">document base URL</a>. 
     <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-sizes">sizes</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartworkinit-sizes">sizes</a></code>. 
     <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-type">type</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartworkinit-type">type</a></code>. 
     <li> Return <var>metadata</var>. 
    </ol>
-   <p>The MediaArtwork <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-src">src</a>, <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-sizes">sizes</a> and <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-type">type</a> inspired from the <a data-link-type="dfn" href="http://www.w3.org/TR/appmanifest/#dfn-image-object">image object</a>s in Web App Manifest.</p>
+   <p>The MediaArtwork <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-src">src</a>, <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-sizes">sizes</a> and <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-type">type</a> inspired from the <a data-link-type="dfn" href="https://www.w3.org/TR/appmanifest/#dfn-image-object">image object</a>s in Web App Manifest.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="attribute" data-export="" id="dom-mediaartwork-src">src<a class="self-link" href="#dom-mediaartwork-src"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object’s <a data-link-type="dfn" href="#mediaartwork-source">source</a>. It is a URL from
 which the user agent can fetch the image’s data.</p>
-   <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="attribute" data-export="" id="dom-mediaartwork-sizes">sizes<a class="self-link" href="#dom-mediaartwork-sizes"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object’s <a data-link-type="dfn" href="#mediaartwork-sizes">sizes</a>. It is a string
-consisting of an unordered set of unique space-separated tokens which are AScII
-case insensitive that represents the dimensions of an image. Each keyword is
-either an ASCII case-insensitive match for the string "any", or a value that
-consists of two valid non-negative integers that do not have a leading U+0030
-DIGIT ZERO (0) character and that are separated by a single U+0078 LATIN SMALL
-LETTER X or U+0058 LATIN CAPITAL LETTER X character. The keywords represent icon
-sizes in raw pixels (as opposed to CSS pixels). When multiple image objects are
-available, a user agent may use the value to decide which icon is most suitable
-for a display context (and ignore any that are inappropriate).</p>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="attribute" data-export="" id="dom-mediaartwork-sizes">sizes<a class="self-link" href="#dom-mediaartwork-sizes"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object’s <a data-link-type="dfn" href="#mediaartwork-sizes">sizes</a>. It follows the spec
+of <a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-sizes"><code>sizes</code></a> attribute in HTML <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element"><code>link</code></a> element, which is a
+string consisting of an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#unordered-set-of-unique-space-separated-tokens">unordered set of unique space-separated
+tokens</a> which are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive</a> that represents the
+dimensions of an image. Each keyword is either an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII
+case-insensitive</a> match for the string "any", or a value that
+consists of two valid non-negative integers that do not have a leading
+U+0030 DIGIT ZERO (0) character and that are separated by a single
+U+0078 LATIN SMALL LETTER X or U+0058 LATIN CAPITAL LETTER X
+character. The keywords represent icon sizes in raw pixels (as opposed
+to CSS pixels). When multiple image objects are available, a user
+agent may use the value to decide which icon is most suitable for a
+display context (and ignore any that are inappropriate). The parsing
+steps for the <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-sizes">sizes</a> attribute must
+follow <a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-sizes">the parsing steps
+for HTML <code>link</code> element <code>sizes</code> attribute</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="attribute" data-export="" id="dom-mediaartwork-type">type<a class="self-link" href="#dom-mediaartwork-type"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object’s <a data-link-type="dfn" href="#mediaartwork-type">type</a>. It is a hint as to the
 media type of the image. The purpose of attribute is to allow a user agent to
 ignore images of media types it does not support.</p>
@@ -992,8 +997,8 @@ media session from an <code class="idl"><a data-link-type="idl" href="https://we
    <p>When the user agent is to <dfn data-dfn-type="dfn" data-noexport="" id="resume-a-web-audio-object">resume a web audio object<a class="self-link" href="#resume-a-web-audio-object"></a></dfn> for a given <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#audiocontext">AudioContext</a></code> object it must invoke that <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#audiocontext">AudioContext</a></code> object’s <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#widl-AudioContext-resume-Promise-void">resume()</a></code> method.</p>
    <h2 class="heading settled" data-level="9" id="examples"><span class="secno">9. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
    <p><em>This section is non-normative.</em></p>
-   <div class="example" id="example-8205a328">
-    <a class="self-link" href="#example-8205a328"></a> For music or podcasts, using a <a data-link-type="dfn" href="#media-session">media session</a> of <a data-link-type="dfn" href="#mediasession-kind">kind</a> "<code><a data-link-type="dfn" href="#content">content</a></code>" can be appropriate. 
+   <div class="example" id="example-5fad9406">
+    <a class="self-link" href="#example-5fad9406"></a> For music or podcasts, using a <a data-link-type="dfn" href="#media-session">media session</a> of <a data-link-type="dfn" href="#mediasession-kind">kind</a> "<code><a data-link-type="dfn" href="#content">content</a></code>" can be appropriate. 
 <pre class="lang-javascript highlight"><span></span><span class="kd">var</span> <span class="nx">audio</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">createElement</span><span class="p">(</span><span class="s2">"audio"</span><span class="p">);</span>
 <span class="nx">audio</span><span class="p">.</span><span class="nx">src</span> <span class="o">=</span> <span class="s2">"podcast.mp3"</span><span class="p">;</span>
 <span class="nx">audio</span><span class="p">.</span><span class="nx">session</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">MediaSession</span><span class="p">();</span> <span class="c1">// "content" is the default kind</span>
@@ -1003,15 +1008,17 @@ media session from an <code class="idl"><a data-link-type="idl" href="https://we
   <span class="nx">title</span><span class="o">:</span> <span class="s2">"Episode Title"</span><span class="p">,</span>
   <span class="nx">artist</span><span class="o">:</span> <span class="s2">"Podcast Host"</span><span class="p">,</span>
   <span class="nx">album</span><span class="o">:</span> <span class="s2">"Podcast Title"</span><span class="p">,</span>
-  <span class="nx">artworks</span><span class="o">:</span> <span class="p">[{</span><span class="nx">src</span><span class="o">:</span> <span class="s2">"podcast.jpg"</span><span class="p">}]</span>
+  <span class="nx">artwork</span><span class="o">:</span> <span class="p">[{</span><span class="nx">src</span><span class="o">:</span> <span class="s2">"podcast.jpg"</span><span class="p">}]</span>
 <span class="p">});</span></pre>
-    <p>Alternatively, providing multiple artworks in the metadata can let the user
-  agent be able to select different artworks for different display purposes:</p>
+    <p>Alternatively, providing multiple <a data-link-type="dfn" href="#mediametadata-artwork-images" title="artwork
+  image">artwork images</a> in the metadata can let the user agent be able to
+  select different artwork images for different display purposes and better fit
+  for different screens:</p>
 <pre class="lang-javascript highlight"><span></span><span class="nx">audio</span><span class="p">.</span><span class="nx">session</span><span class="p">.</span><span class="nx">metadata</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">MediaMetadata</span><span class="p">({</span>
   <span class="nx">title</span><span class="o">:</span> <span class="s2">"Episode Title"</span><span class="p">,</span>
   <span class="nx">artist</span><span class="o">:</span> <span class="s2">"Podcast Host"</span><span class="p">,</span>
   <span class="nx">album</span><span class="o">:</span> <span class="s2">"Podcast Title"</span><span class="p">,</span>
-  <span class="nx">artworks</span><span class="o">:</span> <span class="p">[</span>
+  <span class="nx">artwork</span><span class="o">:</span> <span class="p">[</span>
     <span class="p">{</span><span class="nx">src</span><span class="o">:</span> <span class="s2">"podcast.jpg"</span><span class="p">,</span> <span class="nx">sizes</span><span class="o">:</span> <span class="s2">"128x128"</span><span class="p">,</span> <span class="nx">type</span><span class="o">:</span> <span class="s2">"image/jpeg"</span><span class="p">},</span>
     <span class="p">{</span><span class="nx">src</span><span class="o">:</span> <span class="s2">"podcast_hd.jpg"</span><span class="p">,</span> <span class="nx">sizes</span><span class="o">:</span> <span class="s2">"256x256"</span><span class="p">},</span>
     <span class="p">{</span><span class="nx">src</span><span class="o">:</span> <span class="s2">"podcast_xhd.jpg"</span><span class="p">,</span> <span class="nx">sizes</span><span class="o">:</span> <span class="s2">"1024x1024"</span><span class="p">,</span> <span class="nx">type</span><span class="o">:</span> <span class="s2">"image/jpeg"</span><span class="p">},</span>
@@ -1024,8 +1031,8 @@ media session from an <code class="idl"><a data-link-type="idl" href="https://we
   low-pixel-density screen, and <code>"podcast_hd.jpg"</code> or <code>"podcast_hd.png"</code> for a high-pixel-density screen. If the user
   agent want to use an image for lockscreen background, <code>"podcast_xhd.jpg"</code> will be prefered.</p>
    </div>
-   <div class="example" id="example-e84dc250">
-    <a class="self-link" href="#example-e84dc250"></a> For playlists or chapters of an audio book, multiple <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media elements</a> can
+   <div class="example" id="example-c5521ca0">
+    <a class="self-link" href="#example-c5521ca0"></a> For playlists or chapters of an audio book, multiple <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media elements</a> can
   share a single <a data-link-type="dfn" href="#media-session">media session</a>. 
 <pre class="lang-javascript highlight"><span></span><span class="kd">var</span> <span class="nx">audio1</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">createElement</span><span class="p">(</span><span class="s2">"audio"</span><span class="p">);</span>
 <span class="nx">audio1</span><span class="p">.</span><span class="nx">src</span> <span class="o">=</span> <span class="s2">"chapter1.mp3"</span><span class="p">;</span>
@@ -1047,7 +1054,7 @@ media session from an <code class="idl"><a data-link-type="idl" href="https://we
     <span class="nx">title</span><span class="o">:</span> <span class="nx">event</span><span class="p">.</span><span class="nx">target</span> <span class="o">==</span> <span class="nx">audio1</span> <span class="o">?</span> <span class="s2">"Chapter 1"</span> <span class="o">:</span> <span class="s2">"Chapter 2"</span><span class="p">,</span>
     <span class="nx">artist</span><span class="o">:</span> <span class="s2">"An Author"</span><span class="p">,</span>
     <span class="nx">album</span><span class="o">:</span> <span class="s2">"A Book"</span><span class="p">,</span>
-    <span class="nx">artworks</span><span class="o">:</span> <span class="p">[{</span><span class="nx">src</span><span class="o">:</span> <span class="s2">"cover.jpg"</span><span class="p">}]</span>
+    <span class="nx">artwork</span><span class="o">:</span> <span class="p">[{</span><span class="nx">src</span><span class="o">:</span> <span class="s2">"cover.jpg"</span><span class="p">}]</span>
   <span class="p">});</span>
 <span class="p">}</span>
 
@@ -1109,12 +1116,13 @@ neighboring rights to this work.</p>
      <li><a href="#dom-mediametadata-artist">attribute for MediaMetadata</a><span>, in §5</span>
     </ul>
    <li>
-    artworks
+    artwork
     <ul>
-     <li><a href="#dom-mediametadatainit-artworks">dict-member for MediaMetadataInit</a><span>, in §5</span>
-     <li><a href="#mediametadata-artworks">dfn for MediaMetadata</a><span>, in §5</span>
-     <li><a href="#dom-mediametadata-artworks">attribute for MediaMetadata</a><span>, in §5</span>
+     <li><a href="#dom-mediametadatainit-artwork">dict-member for MediaMetadataInit</a><span>, in §5</span>
+     <li><a href="#dom-mediametadata-artwork">attribute for MediaMetadata</a><span>, in §5</span>
     </ul>
+   <li><a href="#mediametadata-artwork-images">artwork
+images</a><span>, in §5</span>
    <li><a href="#audio-producing-object">audio-producing object</a><span>, in §4.3</span>
    <li><a href="#audio-producing-participants">audio-producing participants</a><span>, in §4.3</span>
    <li>
@@ -1142,12 +1150,7 @@ neighboring rights to this work.</p>
    <li><a href="#dictdef-mediaartworkinit">MediaArtworkInit</a><span>, in §6</span>
    <li><a href="#dom-mediaartwork-mediaartwork">MediaArtwork(init)</a><span>, in §6</span>
    <li><a href="#mediametadata">MediaMetadata</a><span>, in §5</span>
-   <li>
-    MediaMetadata(init)
-    <ul>
-     <li><a href="#dom-mediametadata-mediametadata">constructor for MediaMetadata</a><span>, in §5</span>
-     <li><a href="#dom-mediaartwork-mediametadata">constructor for MediaArtwork</a><span>, in §6</span>
-    </ul>
+   <li><a href="#dom-mediametadata-mediametadata">MediaMetadata(init)</a><span>, in §5</span>
    <li><a href="#dictdef-mediametadatainit">MediaMetadataInit</a><span>, in §5</span>
    <li><a href="#media-session">media session</a><span>, in §4</span>
    <li><a href="#mediasession">MediaSession</a><span>, in §4</span>
@@ -1160,8 +1163,8 @@ neighboring rights to this work.</p>
    <li><a href="#dom-mediasession-metadata">metadata</a><span>, in §4</span>
    <li><a href="#pause">pause</a><span>, in §4.3</span>
    <li><a href="#pause-a-media-element">pause a media element</a><span>, in §7.2</span>
-   <li><a href="#prefered-artwork">prefered
-    artwork</a><span>, in §5</span>
+   <li><a href="#prefered-artwork-image">prefered
+    artwork image</a><span>, in §5</span>
    <li><a href="#release-media-element-from-its-media-session">release media element from its media
 session</a><span>, in §7.3</span>
    <li><a href="#resume-a-web-audio-object">resume a web audio object</a><span>, in §8.1</span>
@@ -1238,18 +1241,23 @@ session</a><span>, in §7.3</span>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-network_idle">NETWORK_IDLE</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-network_loading">NETWORK_LOADING</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ascii case-insensitive</a>
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitivity-and-string-comparison">case-sensitive</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-media-controls">controls</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#document-base-url">document base url</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#ended-playback">ended playback</a>
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#internal-pause-steps">internal pause steps</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element-load-algorithm">media element load algorithm</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-networkstate">networkState</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-paused">paused</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-play">play()</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-readystate">readyState</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-sizes">sizes</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#unordered-set-of-unique-space-separated-tokens">unordered set of unique space-separated tokens</a>
     </ul>
    <li>
     <a data-link-type="biblio">[page-visibility]</a> defines the following terms:
@@ -1271,7 +1279,7 @@ session</a><span>, in §7.3</span>
    <li>
     <a data-link-type="biblio">[appmanifest]</a> defines the following terms:
     <ul>
-     <li><a href="http://www.w3.org/TR/appmanifest/#dfn-image-object">image object</a>
+     <li><a href="https://www.w3.org/TR/appmanifest/#dfn-image-object">image object</a>
     </ul>
    <li>
     <a data-link-type="biblio">[WHATWG-DOM]</a> defines the following terms:
@@ -1321,17 +1329,17 @@ interface <a href="#mediametadata">MediaMetadata</a> {
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-title">title</a>;
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-artist">artist</a>;
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-album">album</a>;
-  readonly attribute FrozenArray&lt;<a data-link-type="idl-name" href="#mediaartwork">MediaArtwork</a>> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="FrozenArray<MediaArtwork>" href="#dom-mediametadata-artworks">artworks</a>;
+  [SameObject] readonly attribute FrozenArray&lt;<a data-link-type="idl-name" href="#mediaartwork">MediaArtwork</a>> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="FrozenArray<MediaArtwork>" href="#dom-mediametadata-artwork">artwork</a>;
 };
 
 dictionary <a href="#dictdef-mediametadatainit">MediaMetadataInit</a> {
   DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediametadatainit-title">title</a> = "";
   DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediametadatainit-artist">artist</a> = "";
   DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediametadatainit-album">album</a> = "";
-  sequence&lt;<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a>> <a data-default="None" data-type="sequence<MediaArtworkInit> " href="#dom-mediametadatainit-artworks">artworks</a> = [];
+  sequence&lt;<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a>> <a data-default="None" data-type="sequence<MediaArtworkInit> " href="#dom-mediametadatainit-artwork">artwork</a> = [];
 };
 
-[<a href="#dom-mediaartwork-mediaartwork">Constructor</a>(<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a> <a href="#dom-mediaartwork-mediaartwork-init-init">init</a>)]
+[<a class="idl-code" data-link-type="constructor" href="#dom-mediaartwork-mediaartwork">Constructor</a>(<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a> <a href="#dom-mediaartwork-mediaartwork-init-init">init</a>)]
 interface <a href="#mediaartwork">MediaArtwork</a> {
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-src">src</a>;
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-sizes">sizes</a>;

--- a/mediasession.html
+++ b/mediasession.html
@@ -225,7 +225,7 @@
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-mediasession.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref" id="title">Media Session</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-06-08">8 June 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-06-21">21 June 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -264,7 +264,7 @@ notification areas and on lock screens of mobile devices.</p>
       <li><a href="#deactivating-a-media-session"><span class="secno">4.6</span> <span class="content">Deactivating a media session</span></a>
      </ol>
     <li><a href="#the-mediametadata-interface"><span class="secno">5</span> <span class="content">The <code class="idl"><span>MediaMetadata</span></code> interface</span></a>
-    <li><a href="#the-mediaartwork-interface"><span class="secno">6</span> <span class="content">The <code class="idl"><span>MediaArtwork</span></code> interface</span></a>
+    <li><a href="#the-mediaimage-interface"><span class="secno">6</span> <span class="content">The <code class="idl"><span>MediaImage</span></code> interface</span></a>
     <li>
      <a href="#extensions-to-the-htmlmediaelement-interface"><span class="secno">7</span> <span class="content">Extensions to the <code class="idl"><span>HTMLMediaElement</span></code> interface</span></a>
      <ol class="toc">
@@ -813,14 +813,14 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="med
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-title">title</a>;
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-artist">artist</a>;
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-album">album</a>;
-  [SameObject] readonly attribute FrozenArray&lt;<a data-link-type="idl-name" href="#mediaartwork">MediaArtwork</a>> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="FrozenArray<MediaArtwork>" href="#dom-mediametadata-artwork">artwork</a>;
+  [SameObject] readonly attribute FrozenArray&lt;<a data-link-type="idl-name" href="#mediaimage">MediaImage</a>> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="FrozenArray<MediaImage>" href="#dom-mediametadata-artwork">artwork</a>;
 };
 
 dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-mediametadatainit">MediaMetadataInit<a class="self-link" href="#dictdef-mediametadatainit"></a></dfn> {
   DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediametadatainit-title">title<a class="self-link" href="#dom-mediametadatainit-title"></a></dfn> = "";
   DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediametadatainit-artist">artist<a class="self-link" href="#dom-mediametadatainit-artist"></a></dfn> = "";
   DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediametadatainit-album">album<a class="self-link" href="#dom-mediametadatainit-album"></a></dfn> = "";
-  sequence&lt;<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a>> <dfn class="idl-code" data-default="None" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MediaArtworkInit> " id="dom-mediametadatainit-artwork">artwork<a class="self-link" href="#dom-mediametadatainit-artwork"></a></dfn> = [];
+  sequence&lt;<a data-link-type="idl-name" href="#dictdef-mediaimageinit">MediaImageInit</a>> <dfn class="idl-code" data-default="None" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MediaImageInit> " id="dom-mediametadatainit-artwork">artwork<a class="self-link" href="#dom-mediametadatainit-artwork"></a></dfn> = [];
 };
 </pre>
    <p>A <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> object has a <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-title">title<a class="self-link" href="#mediametadata-title"></a></dfn>, an <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-artist">artist<a class="self-link" href="#mediametadata-artist"></a></dfn>, an <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-album">album<a class="self-link" href="#mediametadata-album"></a></dfn> and a
@@ -832,7 +832,7 @@ images<a class="self-link" href="#mediametadata-artwork-images"></a></dfn>.</p>
     <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-title">title</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-title">title</a></code>. 
     <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-artist">artist</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-artist">artist</a></code>. 
     <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-album">album</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-album">album</a></code>. 
-    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-artwork">artwork</a></code> using <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-artwork">artwork</a></code> by calling the <a data-link-type="functionish" href="#dom-mediaartwork-mediaartwork"><code>MediaArtwork(init)</code></a> constructor. 
+    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-artwork">artwork</a></code> using <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-artwork">artwork</a></code> by calling the <a data-link-type="functionish" href="#dom-mediaimage-mediaimage"><code>MediaImage(init)</code></a> constructor. 
     <li> Return <var>metadata</var>. 
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" id="dom-mediametadata-title"><code>title</code><a class="self-link" href="#dom-mediametadata-title"></a></dfn> attribute must
@@ -841,74 +841,69 @@ return the <code class="idl"><a data-link-type="idl" href="#mediametadata">Media
 return the <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> objects’s <a data-link-type="dfn" href="#mediametadata-artist">artist</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" id="dom-mediametadata-album"><code>album</code><a class="self-link" href="#dom-mediametadata-album"></a></dfn> attribute must
 return the <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> objects’s <a data-link-type="dfn" href="#mediametadata-album">album</a>.</p>
-   <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" id="dom-mediametadata-artwork"><code>artwork</code><a class="self-link" href="#dom-mediametadata-artwork"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> objects’s <a data-link-type="dfn" href="#mediametadata-artwork-images" title="artwork image">artwork images</a>, as a FrozenArray of <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code>s.
+   <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" id="dom-mediametadata-artwork"><code>artwork</code><a class="self-link" href="#dom-mediametadata-artwork"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> objects’s <a data-link-type="dfn" href="#mediametadata-artwork-images" title="artwork image">artwork images</a>, as a FrozenArray of <code class="idl"><a data-link-type="idl" href="#mediaimage">MediaImage</a></code>s.
 The <a class="idl-code" data-link-type="attribute" href="#dom-mediametadata-artwork">artwork</a> attribute can be empty.</p>
-   <p>When the user agent wants to display the <code class="idl"><a data-link-type="idl" href="#mediasession">MediaSession</a></code>'s artwork
-as specified in it’s <var>metadata</var>, it is recommended to run the
-following <dfn data-dfn-type="dfn" data-noexport="" id="fetch-steps">fetch steps<a class="self-link" href="#fetch-steps"></a></dfn>:</p>
+   <p>When a user agent wants to display the <code class="idl"><a data-link-type="idl" href="#mediasession">MediaSession</a></code>'s artwork as specified
+in it’s <var>metadata</var>, it is recommended to run the following <dfn data-dfn-type="dfn" data-noexport="" id="fetch-steps">fetch
+steps<a class="self-link" href="#fetch-steps"></a></dfn>:</p>
    <ol>
     <li> If <var>metadata</var>’s <a class="idl-code" data-link-type="attribute" href="#dom-mediametadata-artwork"><code>artwork</code></a> is empty, then terminate these
     steps. 
     <li> If the platform supports displaying media artwork, select a <dfn data-dfn-type="dfn" data-noexport="" id="prefered-artwork-image">prefered
     artwork image<a class="self-link" href="#prefered-artwork-image"></a></dfn> from <var>metadata</var>’s <a class="idl-code" data-link-type="attribute" href="#dom-mediametadata-artwork"><code>artwork</code></a>. 
     <li>
-      <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" title="fetch">Fetch</a> <a data-link-type="dfn" href="#prefered-artwork-image">prefered artwork image</a>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-src">src</a></code>. 
+      <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" title="fetch">Fetch</a> <a data-link-type="dfn" href="#prefered-artwork-image">prefered artwork image</a>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaimage-src">src</a></code>. 
      <p>Then, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
      <ol>
       <li> Wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>. 
       <li> If the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-internal-response">internal response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type">type</a> is <i>default</i>, attempt to decode the
         resource as image. 
-      <li> If the image format is supported, use the image as the artwork
-        for display. (Otherwise the fetch step fails and the user
-        agent may take fallback actions.) 
+      <li> If the image format is supported, use the image as the artwork for
+        display. Otherwise the <a data-link-type="dfn" href="#fetch-steps">fetch steps</a> fail and terminate. 
      </ol>
    </ol>
-   <h2 class="heading settled" data-level="6" id="the-mediaartwork-interface"><span class="secno">6. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> interface</span><a class="self-link" href="#the-mediaartwork-interface"></a></h2>
-<pre class="idl def">[<a class="idl-code" data-link-type="constructor" href="#dom-mediaartwork-mediaartwork">Constructor</a>(<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a> <dfn class="idl-code" data-dfn-for="MediaArtwork/MediaArtwork(init)" data-dfn-type="argument" data-export="" id="dom-mediaartwork-mediaartwork-init-init">init<a class="self-link" href="#dom-mediaartwork-mediaartwork-init-init"></a></dfn>)]
-interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="mediaartwork">MediaArtwork<a class="self-link" href="#mediaartwork"></a></dfn> {
-  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-src">src</a>;
-  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-sizes">sizes</a>;
-  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-type">type</a>;
+   <p>If no artwork images are fetched in the <a data-link-type="dfn" href="#fetch-steps">fetch steps</a>, the user agent may
+have fallback behavior such as displaying an default image as artwork.</p>
+   <h2 class="heading settled" data-level="6" id="the-mediaimage-interface"><span class="secno">6. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#mediaimage">MediaImage</a></code> interface</span><a class="self-link" href="#the-mediaimage-interface"></a></h2>
+<pre class="idl def">[<a class="idl-code" data-link-type="constructor" href="#dom-mediaimage-mediaimage">Constructor</a>(<a data-link-type="idl-name" href="#dictdef-mediaimageinit">MediaImageInit</a> <dfn class="idl-code" data-dfn-for="MediaImage/MediaImage(init)" data-dfn-type="argument" data-export="" id="dom-mediaimage-mediaimage-init-init">init<a class="self-link" href="#dom-mediaimage-mediaimage-init-init"></a></dfn>)]
+interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="mediaimage">MediaImage<a class="self-link" href="#mediaimage"></a></dfn> {
+  readonly attribute USVString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-mediaimage-src">src</a>;
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaimage-sizes">sizes</a>;
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaimage-type">type</a>;
 };
 
-dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-mediaartworkinit">MediaArtworkInit<a class="self-link" href="#dictdef-mediaartworkinit"></a></dfn> {
-  DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaArtworkInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediaartworkinit-src">src<a class="self-link" href="#dom-mediaartworkinit-src"></a></dfn> = "";
-  DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaArtworkInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediaartworkinit-sizes">sizes<a class="self-link" href="#dom-mediaartworkinit-sizes"></a></dfn> = "";
-  DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaArtworkInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediaartworkinit-type">type<a class="self-link" href="#dom-mediaartworkinit-type"></a></dfn> = "";
+dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-mediaimageinit">MediaImageInit<a class="self-link" href="#dictdef-mediaimageinit"></a></dfn> {
+  USVString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaImageInit" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-mediaimageinit-src">src<a class="self-link" href="#dom-mediaimageinit-src"></a></dfn> = "";
+  DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaImageInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediaimageinit-sizes">sizes<a class="self-link" href="#dom-mediaimageinit-sizes"></a></dfn> = "";
+  DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaImageInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediaimageinit-type">type<a class="self-link" href="#dom-mediaimageinit-type"></a></dfn> = "";
 };
 </pre>
-   <p>A <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object has a <dfn data-dfn-for="MediaArtwork" data-dfn-type="dfn" data-noexport="" id="mediaartwork-source">source<a class="self-link" href="#mediaartwork-source"></a></dfn>, a list of <dfn data-dfn-for="MediaArtwork" data-dfn-type="dfn" data-noexport="" id="mediaartwork-sizes">sizes<a class="self-link" href="#mediaartwork-sizes"></a></dfn>, and a <dfn data-dfn-for="MediaArtwork" data-dfn-type="dfn" data-noexport="" id="mediaartwork-type">type<a class="self-link" href="#mediaartwork-type"></a></dfn>.</p>
-   <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="constructor" data-export="" id="dom-mediaartwork-mediaartwork"><code>MediaArtwork(<var>init</var>)</code><a class="self-link" href="#dom-mediaartwork-mediaartwork"></a></dfn> constructor, when invoked, must run the following steps:</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#mediaimage">MediaImage</a></code> object has a <dfn data-dfn-for="MediaImage" data-dfn-type="dfn" data-noexport="" id="mediaimage-source">source<a class="self-link" href="#mediaimage-source"></a></dfn>, a list of <dfn data-dfn-for="MediaImage" data-dfn-type="dfn" data-noexport="" id="mediaimage-sizes">sizes<a class="self-link" href="#mediaimage-sizes"></a></dfn>, and a <dfn data-dfn-for="MediaImage" data-dfn-type="dfn" data-noexport="" id="mediaimage-type">type<a class="self-link" href="#mediaimage-type"></a></dfn>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaImage" data-dfn-type="constructor" data-export="" id="dom-mediaimage-mediaimage"><code>MediaImage(<var>init</var>)</code><a class="self-link" href="#dom-mediaimage-mediaimage"></a></dfn> constructor, when invoked, must run the following steps:</p>
    <ol>
-    <li> Let <var>metadata</var> be a new <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object. 
-    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-src">src</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartworkinit-src">src</a></code>. If the URL is a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#syntax-url-relative">relative URL</a>, it must be resolved to an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#syntax-url-absolute">absolute URL</a> using
-    the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#document-base-url">document base URL</a>. 
-    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-sizes">sizes</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartworkinit-sizes">sizes</a></code>. 
-    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-type">type</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartworkinit-type">type</a></code>. 
+    <li> Let <var>metadata</var> be a new <code class="idl"><a data-link-type="idl" href="#mediaimage">MediaImage</a></code> object. 
+    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaimage-src">src</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaimageinit-src">src</a></code>. If the URL is a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#syntax-url-relative">relative URL</a>, it must be resolved to an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#syntax-url-absolute">absolute URL</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#document-base-url">document base URL</a>. 
+    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaimage-sizes">sizes</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaimageinit-sizes">sizes</a></code>. 
+    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaimage-type">type</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaimageinit-type">type</a></code>. 
     <li> Return <var>metadata</var>. 
    </ol>
-   <p>The MediaArtwork <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-src">src</a>, <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-sizes">sizes</a> and <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-type">type</a> inspired from the <a data-link-type="dfn" href="https://www.w3.org/TR/appmanifest/#dfn-image-object">image object</a>s in Web App Manifest.</p>
-   <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="attribute" data-export="" id="dom-mediaartwork-src">src<a class="self-link" href="#dom-mediaartwork-src"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object’s <a data-link-type="dfn" href="#mediaartwork-source">source</a>. It is a URL from
+   <p>The MediaImage <a class="idl-code" data-link-type="attribute" href="#dom-mediaimage-src">src</a>, <a class="idl-code" data-link-type="attribute" href="#dom-mediaimage-sizes">sizes</a> and <a class="idl-code" data-link-type="attribute" href="#dom-mediaimage-type">type</a> inspired from the <a data-link-type="dfn" href="https://www.w3.org/TR/appmanifest/#dfn-image-object">image objects</a> in Web App Manifest.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaImage" data-dfn-type="attribute" data-export="" id="dom-mediaimage-src">src<a class="self-link" href="#dom-mediaimage-src"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaimage">MediaImage</a></code> object’s <a data-link-type="dfn" href="#mediaimage-source">source</a>. It is a URL from
 which the user agent can fetch the image’s data.</p>
-   <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="attribute" data-export="" id="dom-mediaartwork-sizes">sizes<a class="self-link" href="#dom-mediaartwork-sizes"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object’s <a data-link-type="dfn" href="#mediaartwork-sizes">sizes</a>. It follows the spec
-of <a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-sizes"><code>sizes</code></a> attribute in HTML <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element"><code>link</code></a> element, which is a
-string consisting of an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#unordered-set-of-unique-space-separated-tokens">unordered set of unique space-separated
-tokens</a> which are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive</a> that represents the
-dimensions of an image. Each keyword is either an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII
-case-insensitive</a> match for the string "any", or a value that
-consists of two valid non-negative integers that do not have a leading
-U+0030 DIGIT ZERO (0) character and that are separated by a single
-U+0078 LATIN SMALL LETTER X or U+0058 LATIN CAPITAL LETTER X
-character. The keywords represent icon sizes in raw pixels (as opposed
-to CSS pixels). When multiple image objects are available, a user
-agent may use the value to decide which icon is most suitable for a
-display context (and ignore any that are inappropriate). The parsing
-steps for the <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-sizes">sizes</a> attribute must
-follow <a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-sizes">the parsing steps
-for HTML <code>link</code> element <code>sizes</code> attribute</a>.</p>
-   <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="attribute" data-export="" id="dom-mediaartwork-type">type<a class="self-link" href="#dom-mediaartwork-type"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object’s <a data-link-type="dfn" href="#mediaartwork-type">type</a>. It is a hint as to the
-media type of the image. The purpose of attribute is to allow a user agent to
-ignore images of media types it does not support.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaImage" data-dfn-type="attribute" data-export="" id="dom-mediaimage-sizes">sizes<a class="self-link" href="#dom-mediaimage-sizes"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaimage">MediaImage</a></code> object’s <a data-link-type="dfn" href="#mediaimage-sizes">sizes</a>. It follows the spec
+of <a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-sizes"><code>sizes</code></a> attribute in HTML <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element"><code>link</code></a> element, which is a string
+consisting of an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#unordered-set-of-unique-space-separated-tokens">unordered set of unique space-separated tokens</a> which are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive</a> that represents the dimensions of an image. Each
+keyword is either an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive</a> match for the string "any",
+or a value that consists of two valid non-negative integers that do not have a
+leading U+0030 DIGIT ZERO (0) character and that are separated by a single
+U+0078 LATIN SMALL LETTER X or U+0058 LATIN CAPITAL LETTER X character. The
+keywords represent icon sizes in raw pixels (as opposed to CSS pixels). When
+multiple image objects are available, a user agent may use the value to decide
+which icon is most suitable for a display context (and ignore any that are
+inappropriate). The parsing steps for the <a class="idl-code" data-link-type="attribute" href="#dom-mediaimage-sizes">sizes</a> attribute must follow <a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-sizes">the parsing steps for HTML <code>link</code> element <code>sizes</code> attribute</a>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaImage" data-dfn-type="attribute" data-export="" id="dom-mediaimage-type">type<a class="self-link" href="#dom-mediaimage-type"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaimage">MediaImage</a></code> object’s <a data-link-type="dfn" href="#mediaimage-type">type</a>. It is a hint as to the
+media type of the image. The purpose of this attribute is to allow a user agent
+to ignore images of media types it does not support.</p>
    <h2 class="heading settled" data-level="7" id="extensions-to-the-htmlmediaelement-interface"><span class="secno">7. </span><span class="content">Extensions to the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a></code> interface</span><a class="self-link" href="#extensions-to-the-htmlmediaelement-interface"></a></h2>
 <pre class="idl def">partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a> {
   attribute <a data-link-type="idl-name" href="#mediasession">MediaSession</a>? <a class="idl-code" data-link-type="attribute" data-type="MediaSession?" href="#dom-htmlmediaelement-session">session</a>;
@@ -1136,7 +1131,8 @@ images</a><span>, in §5</span>
    <li><a href="#deactivate">deactivate</a><span>, in §4.6</span>
    <li><a href="#dom-mediasession-deactivate">deactivate()</a><span>, in §4</span>
    <li><a href="#duck">duck</a><span>, in §4.3</span>
-   <li><a href="#fetch-steps">fetch steps</a><span>, in §5</span>
+   <li><a href="#fetch-steps">fetch
+steps</a><span>, in §5</span>
    <li><a href="#idle-media-session-state">idle media session state</a><span>, in §4.1</span>
    <li><a href="#indefinitely-pause">indefinitely pause</a><span>, in §4.3</span>
    <li><a href="#interrupted-media-session-state">interrupted media session state</a><span>, in §4.1</span>
@@ -1146,9 +1142,9 @@ images</a><span>, in §5</span>
      <li><a href="#dom-mediasession-kind">attribute for MediaSession</a><span>, in §4</span>
      <li><a href="#mediasession-kind">dfn for MediaSession</a><span>, in §4.2</span>
     </ul>
-   <li><a href="#mediaartwork">MediaArtwork</a><span>, in §6</span>
-   <li><a href="#dictdef-mediaartworkinit">MediaArtworkInit</a><span>, in §6</span>
-   <li><a href="#dom-mediaartwork-mediaartwork">MediaArtwork(init)</a><span>, in §6</span>
+   <li><a href="#mediaimage">MediaImage</a><span>, in §6</span>
+   <li><a href="#dom-mediaimage-mediaimage">MediaImage(init)</a><span>, in §6</span>
+   <li><a href="#dictdef-mediaimageinit">MediaImageInit</a><span>, in §6</span>
    <li><a href="#mediametadata">MediaMetadata</a><span>, in §5</span>
    <li><a href="#dom-mediametadata-mediametadata">MediaMetadata(init)</a><span>, in §5</span>
    <li><a href="#dictdef-mediametadatainit">MediaMetadataInit</a><span>, in §5</span>
@@ -1178,16 +1174,16 @@ session</a><span>, in §7.3</span>
    <li>
     sizes
     <ul>
-     <li><a href="#dom-mediaartworkinit-sizes">dict-member for MediaArtworkInit</a><span>, in §6</span>
-     <li><a href="#mediaartwork-sizes">dfn for MediaArtwork</a><span>, in §6</span>
-     <li><a href="#dom-mediaartwork-sizes">attribute for MediaArtwork</a><span>, in §6</span>
+     <li><a href="#dom-mediaimageinit-sizes">dict-member for MediaImageInit</a><span>, in §6</span>
+     <li><a href="#mediaimage-sizes">dfn for MediaImage</a><span>, in §6</span>
+     <li><a href="#dom-mediaimage-sizes">attribute for MediaImage</a><span>, in §6</span>
     </ul>
-   <li><a href="#mediaartwork-source">source</a><span>, in §6</span>
+   <li><a href="#mediaimage-source">source</a><span>, in §6</span>
    <li>
     src
     <ul>
-     <li><a href="#dom-mediaartworkinit-src">dict-member for MediaArtworkInit</a><span>, in §6</span>
-     <li><a href="#dom-mediaartwork-src">attribute for MediaArtwork</a><span>, in §6</span>
+     <li><a href="#dom-mediaimageinit-src">dict-member for MediaImageInit</a><span>, in §6</span>
+     <li><a href="#dom-mediaimage-src">attribute for MediaImage</a><span>, in §6</span>
     </ul>
    <li><a href="#mediasession-state">state</a><span>, in §4.1</span>
    <li><a href="#suspend-a-web-audio-object">suspend a web audio object</a><span>, in §8.1</span>
@@ -1215,9 +1211,9 @@ session</a><span>, in §7.3</span>
    <li>
     type
     <ul>
-     <li><a href="#dom-mediaartworkinit-type">dict-member for MediaArtworkInit</a><span>, in §6</span>
-     <li><a href="#mediaartwork-type">dfn for MediaArtwork</a><span>, in §6</span>
-     <li><a href="#dom-mediaartwork-type">attribute for MediaArtwork</a><span>, in §6</span>
+     <li><a href="#dom-mediaimageinit-type">dict-member for MediaImageInit</a><span>, in §6</span>
+     <li><a href="#mediaimage-type">dfn for MediaImage</a><span>, in §6</span>
+     <li><a href="#dom-mediaimage-type">attribute for MediaImage</a><span>, in §6</span>
     </ul>
    <li><a href="#unduck">unduck</a><span>, in §4.3</span>
    <li><a href="#unpause">unpause</a><span>, in §4.3</span>
@@ -1268,6 +1264,12 @@ session</a><span>, in §7.3</span>
      <li><a href="http://www.w3.org/TR/page-visibility/#pv-page-visible">visible</a>
     </ul>
    <li>
+    <a data-link-type="biblio">[WHATWG-URL]</a> defines the following terms:
+    <ul>
+     <li><a href="https://url.spec.whatwg.org/#syntax-url-absolute">absolute url</a>
+     <li><a href="https://url.spec.whatwg.org/#syntax-url-relative">relative url</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[webaudio]</a> defines the following terms:
     <ul>
      <li><a href="https://webaudio.github.io/web-audio-api/#audiocontext">AudioContext</a>
@@ -1306,6 +1308,8 @@ session</a><span>, in §7.3</span>
    <dd>Cameron McCormack; Boris Zbarsky. <a href="https://heycam.github.io/webidl/">WebIDL Level 1</a>. 8 March 2016. CR. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
    <dt id="biblio-whatwg-dom">[WHATWG-DOM]
    <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
+   <dt id="biblio-whatwg-url">[WHATWG-URL]
+   <dd>Anne van Kesteren; Sam Ruby. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl def">[<a class="idl-code" data-link-type="constructor" href="#dom-mediasession-mediasession">Constructor</a>(optional <a data-link-type="idl-name" href="#enumdef-mediasessionkind">MediaSessionKind</a> <a href="#dom-mediasession-mediasession-kind-kind">kind</a> = "content")]
@@ -1329,27 +1333,27 @@ interface <a href="#mediametadata">MediaMetadata</a> {
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-title">title</a>;
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-artist">artist</a>;
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-album">album</a>;
-  [SameObject] readonly attribute FrozenArray&lt;<a data-link-type="idl-name" href="#mediaartwork">MediaArtwork</a>> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="FrozenArray<MediaArtwork>" href="#dom-mediametadata-artwork">artwork</a>;
+  [SameObject] readonly attribute FrozenArray&lt;<a data-link-type="idl-name" href="#mediaimage">MediaImage</a>> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="FrozenArray<MediaImage>" href="#dom-mediametadata-artwork">artwork</a>;
 };
 
 dictionary <a href="#dictdef-mediametadatainit">MediaMetadataInit</a> {
   DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediametadatainit-title">title</a> = "";
   DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediametadatainit-artist">artist</a> = "";
   DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediametadatainit-album">album</a> = "";
-  sequence&lt;<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a>> <a data-default="None" data-type="sequence<MediaArtworkInit> " href="#dom-mediametadatainit-artwork">artwork</a> = [];
+  sequence&lt;<a data-link-type="idl-name" href="#dictdef-mediaimageinit">MediaImageInit</a>> <a data-default="None" data-type="sequence<MediaImageInit> " href="#dom-mediametadatainit-artwork">artwork</a> = [];
 };
 
-[<a class="idl-code" data-link-type="constructor" href="#dom-mediaartwork-mediaartwork">Constructor</a>(<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a> <a href="#dom-mediaartwork-mediaartwork-init-init">init</a>)]
-interface <a href="#mediaartwork">MediaArtwork</a> {
-  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-src">src</a>;
-  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-sizes">sizes</a>;
-  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-type">type</a>;
+[<a class="idl-code" data-link-type="constructor" href="#dom-mediaimage-mediaimage">Constructor</a>(<a data-link-type="idl-name" href="#dictdef-mediaimageinit">MediaImageInit</a> <a href="#dom-mediaimage-mediaimage-init-init">init</a>)]
+interface <a href="#mediaimage">MediaImage</a> {
+  readonly attribute USVString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-mediaimage-src">src</a>;
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaimage-sizes">sizes</a>;
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaimage-type">type</a>;
 };
 
-dictionary <a href="#dictdef-mediaartworkinit">MediaArtworkInit</a> {
-  DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediaartworkinit-src">src</a> = "";
-  DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediaartworkinit-sizes">sizes</a> = "";
-  DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediaartworkinit-type">type</a> = "";
+dictionary <a href="#dictdef-mediaimageinit">MediaImageInit</a> {
+  USVString <a data-default="&quot;&quot;" data-type="USVString " href="#dom-mediaimageinit-src">src</a> = "";
+  DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediaimageinit-sizes">sizes</a> = "";
+  DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediaimageinit-type">type</a> = "";
 };
 
 partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a> {

--- a/mediasession.html
+++ b/mediasession.html
@@ -225,7 +225,7 @@
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-mediasession.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref" id="title">Media Session</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-05-31">31 May 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-06-02">2 June 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -817,18 +817,18 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="med
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-title">title</a>;
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-artist">artist</a>;
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-album">album</a>;
-  readonly attribute sequence&lt;<a data-link-type="idl-name" href="#mediaartwork">MediaArtwork</a>> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="sequence<MediaArtwork>" href="#dom-mediametadata-artworks">artworks</a>;
+  readonly attribute FrozenArray&lt;<a data-link-type="idl-name" href="#mediaartwork">MediaArtwork</a>> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="FrozenArray<MediaArtwork>" href="#dom-mediametadata-artworks">artworks</a>;
 };
 
 dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-mediametadatainit">MediaMetadataInit<a class="self-link" href="#dictdef-mediametadatainit"></a></dfn> {
   DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediametadatainit-title">title<a class="self-link" href="#dom-mediametadatainit-title"></a></dfn> = "";
   DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediametadatainit-artist">artist<a class="self-link" href="#dom-mediametadatainit-artist"></a></dfn> = "";
   DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediametadatainit-album">album<a class="self-link" href="#dom-mediametadatainit-album"></a></dfn> = "";
-  sequence&lt;<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a>>? <dfn class="idl-code" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MediaArtworkInit>? " id="dom-mediametadatainit-artworks">artworks<a class="self-link" href="#dom-mediametadatainit-artworks"></a></dfn>;
+  sequence&lt;<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a>> <dfn class="idl-code" data-default="None" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MediaArtworkInit> " id="dom-mediametadatainit-artworks">artworks<a class="self-link" href="#dom-mediametadatainit-artworks"></a></dfn> = [];
 };
 </pre>
    <p>A <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> object has a <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-title">title<a class="self-link" href="#mediametadata-title"></a></dfn>, an <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-artist">artist<a class="self-link" href="#mediametadata-artist"></a></dfn>, an <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-album">album<a class="self-link" href="#mediametadata-album"></a></dfn> and a
-sequence of <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-artwork">artwork<a class="self-link" href="#mediametadata-artwork"></a></dfn>s.</p>
+FrozenArray of <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-artworks" title="artwork">artworks<a class="self-link" href="#mediametadata-artworks"></a></dfn>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="constructor" data-export="" id="dom-mediametadata-mediametadata"><code>MediaMetadata(<var>init</var>)</code><a class="self-link" href="#dom-mediametadata-mediametadata"></a></dfn> constructor, when invoked, must run the following steps:</p>
    <ol>
     <li> Let <var>metadata</var> be a new <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> object. 
@@ -845,16 +845,16 @@ return the <code class="idl"><a data-link-type="idl" href="#mediametadata">Media
    <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" id="dom-mediametadata-album"><code>album</code><a class="self-link" href="#dom-mediametadata-album"></a></dfn> attribute must
 return the <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> objects’s <a data-link-type="dfn" href="#mediametadata-album">album</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" id="dom-mediametadata-artworks"><code>artworks</code><a class="self-link" href="#dom-mediametadata-artworks"></a></dfn> attribute
-must return the <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> objects’s <a data-link-type="dfn" href="#mediametadata-artwork">artwork</a>s, as a sequence of <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code>s. The <a class="idl-code" data-link-type="attribute" href="#dom-mediametadata-artworks">artworks</a> attribute
+must return the <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> objects’s <a data-link-type="dfn" href="#mediametadata-artworks">artwork</a>s, as a sequence of <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code>s. The <a class="idl-code" data-link-type="attribute" href="#dom-mediametadata-artworks">artworks</a> attribute
 can be empty.</p>
    <p>The <dfn data-dfn-type="dfn" data-noexport="" id="fetch-steps">fetch steps<a class="self-link" href="#fetch-steps"></a></dfn> for a given <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> object <var>metadata</var> are:</p>
    <ol>
-    <li> If <var>metadata</var>’s <a data-link-type="dfn" href="#mediametadata-artwork"><code>artworks</code></a> is empty, then
+    <li> If <var>metadata</var>’s <a data-link-type="dfn" href="#mediametadata-artworks"><code>artworks</code></a> is empty, then
     terminate these steps. 
     <li> If the platform supports displaying media artwork, select a <dfn data-dfn-type="dfn" data-noexport="" id="prefered-artwork">prefered
-    artwork<a class="self-link" href="#prefered-artwork"></a></dfn> from <var>metadata</var>’s <a data-link-type="dfn" href="#mediametadata-artwork"><code>artworks</code></a>. 
+    artwork<a class="self-link" href="#prefered-artwork"></a></dfn> from <var>metadata</var>’s <a data-link-type="dfn" href="#mediametadata-artworks"><code>artworks</code></a>. 
     <li>
-      <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> <a data-link-type="dfn" href="#prefered-artwork">prefered artwork</a>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-src">src</a></code>. 
+      <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" title="fetch">Fetch</a> <a data-link-type="dfn" href="#prefered-artwork">prefered artwork</a>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-src">src</a></code>. 
      <p>Then, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
      <ol>
       <li> Wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>. 
@@ -888,7 +888,7 @@ dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="d
     <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-type">type</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartworkinit-type">type</a></code>. 
     <li> Return <var>metadata</var>. 
    </ol>
-   <p>The MediaArtwork <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-src">src</a>, <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-sizes">sizes</a> and <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-type">type</a> conforms to the <a data-link-type="dfn" href="http://www.w3.org/TR/appmanifest/#dfn-image-object">image object</a>s in Web App Manifest.</p>
+   <p>The MediaArtwork <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-src">src</a>, <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-sizes">sizes</a> and <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-type">type</a> inspired from the <a data-link-type="dfn" href="http://www.w3.org/TR/appmanifest/#dfn-image-object">image object</a>s in Web App Manifest.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="attribute" data-export="" id="dom-mediaartwork-src">src<a class="self-link" href="#dom-mediaartwork-src"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object’s <a data-link-type="dfn" href="#mediaartwork-source">source</a>. It is a URL from
 which the user agent can fetch the image’s data.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="attribute" data-export="" id="dom-mediaartwork-sizes">sizes<a class="self-link" href="#dom-mediaartwork-sizes"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object’s <a data-link-type="dfn" href="#mediaartwork-sizes">sizes</a>. It is a string
@@ -901,8 +901,9 @@ LETTER X or U+0058 LATIN CAPITAL LETTER X character. The keywords represent icon
 sizes in raw pixels (as opposed to CSS pixels). When multiple image objects are
 available, a user agent may use the value to decide which icon is most suitable
 for a display context (and ignore any that are inappropriate).</p>
-   <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="attribute" data-export="" id="dom-mediaartwork-type">type<a class="self-link" href="#dom-mediaartwork-type"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object’s <a data-link-type="dfn" href="#mediaartwork-type">type</a>. It is a MIME type for
-deciding the media type of the image.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="attribute" data-export="" id="dom-mediaartwork-type">type<a class="self-link" href="#dom-mediaartwork-type"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object’s <a data-link-type="dfn" href="#mediaartwork-type">type</a>. It is a hint as to the
+media type of the image. The purpose of attribute is to allow a user agent to
+ignore images of media types it does not support.</p>
    <h2 class="heading settled" data-level="7" id="extensions-to-the-htmlmediaelement-interface"><span class="secno">7. </span><span class="content">Extensions to the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a></code> interface</span><a class="self-link" href="#extensions-to-the-htmlmediaelement-interface"></a></h2>
 <pre class="idl def">partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a> {
   attribute <a data-link-type="idl-name" href="#mediasession">MediaSession</a>? <a class="idl-code" data-link-type="attribute" data-type="MediaSession?" href="#dom-htmlmediaelement-session">session</a>;
@@ -991,8 +992,8 @@ media session from an <code class="idl"><a data-link-type="idl" href="https://we
    <p>When the user agent is to <dfn data-dfn-type="dfn" data-noexport="" id="resume-a-web-audio-object">resume a web audio object<a class="self-link" href="#resume-a-web-audio-object"></a></dfn> for a given <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#audiocontext">AudioContext</a></code> object it must invoke that <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#audiocontext">AudioContext</a></code> object’s <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#widl-AudioContext-resume-Promise-void">resume()</a></code> method.</p>
    <h2 class="heading settled" data-level="9" id="examples"><span class="secno">9. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
    <p><em>This section is non-normative.</em></p>
-   <div class="example" id="example-6fbc8af3">
-    <a class="self-link" href="#example-6fbc8af3"></a> For music or podcasts, using a <a data-link-type="dfn" href="#media-session">media session</a> of <a data-link-type="dfn" href="#mediasession-kind">kind</a> "<code><a data-link-type="dfn" href="#content">content</a></code>" can be appropriate. 
+   <div class="example" id="example-8205a328">
+    <a class="self-link" href="#example-8205a328"></a> For music or podcasts, using a <a data-link-type="dfn" href="#media-session">media session</a> of <a data-link-type="dfn" href="#mediasession-kind">kind</a> "<code><a data-link-type="dfn" href="#content">content</a></code>" can be appropriate. 
 <pre class="lang-javascript highlight"><span></span><span class="kd">var</span> <span class="nx">audio</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">createElement</span><span class="p">(</span><span class="s2">"audio"</span><span class="p">);</span>
 <span class="nx">audio</span><span class="p">.</span><span class="nx">src</span> <span class="o">=</span> <span class="s2">"podcast.mp3"</span><span class="p">;</span>
 <span class="nx">audio</span><span class="p">.</span><span class="nx">session</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">MediaSession</span><span class="p">();</span> <span class="c1">// "content" is the default kind</span>
@@ -1002,13 +1003,29 @@ media session from an <code class="idl"><a data-link-type="idl" href="https://we
   <span class="nx">title</span><span class="o">:</span> <span class="s2">"Episode Title"</span><span class="p">,</span>
   <span class="nx">artist</span><span class="o">:</span> <span class="s2">"Podcast Host"</span><span class="p">,</span>
   <span class="nx">album</span><span class="o">:</span> <span class="s2">"Podcast Title"</span><span class="p">,</span>
-  <span class="nx">artworks</span><span class="o">:</span> <span class="p">{</span>
-    <span class="nx">src</span><span class="o">:</span><span class="s2">"podcast.jpg"</span>
-  <span class="p">}</span>
+  <span class="nx">artworks</span><span class="o">:</span> <span class="p">[{</span><span class="nx">src</span><span class="o">:</span> <span class="s2">"podcast.jpg"</span><span class="p">}]</span>
 <span class="p">});</span></pre>
+    <p>Alternatively, providing multiple artworks in the metadata can let the user
+  agent be able to select different artworks for different display purposes:</p>
+<pre class="lang-javascript highlight"><span></span><span class="nx">audio</span><span class="p">.</span><span class="nx">session</span><span class="p">.</span><span class="nx">metadata</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">MediaMetadata</span><span class="p">({</span>
+  <span class="nx">title</span><span class="o">:</span> <span class="s2">"Episode Title"</span><span class="p">,</span>
+  <span class="nx">artist</span><span class="o">:</span> <span class="s2">"Podcast Host"</span><span class="p">,</span>
+  <span class="nx">album</span><span class="o">:</span> <span class="s2">"Podcast Title"</span><span class="p">,</span>
+  <span class="nx">artworks</span><span class="o">:</span> <span class="p">[</span>
+    <span class="p">{</span><span class="nx">src</span><span class="o">:</span> <span class="s2">"podcast.jpg"</span><span class="p">,</span> <span class="nx">sizes</span><span class="o">:</span> <span class="s2">"128x128"</span><span class="p">,</span> <span class="nx">type</span><span class="o">:</span> <span class="s2">"image/jpeg"</span><span class="p">},</span>
+    <span class="p">{</span><span class="nx">src</span><span class="o">:</span> <span class="s2">"podcast_hd.jpg"</span><span class="p">,</span> <span class="nx">sizes</span><span class="o">:</span> <span class="s2">"256x256"</span><span class="p">},</span>
+    <span class="p">{</span><span class="nx">src</span><span class="o">:</span> <span class="s2">"podcast_xhd.jpg"</span><span class="p">,</span> <span class="nx">sizes</span><span class="o">:</span> <span class="s2">"1024x1024"</span><span class="p">,</span> <span class="nx">type</span><span class="o">:</span> <span class="s2">"image/jpeg"</span><span class="p">},</span>
+    <span class="p">{</span><span class="nx">src</span><span class="o">:</span> <span class="s2">"podcast.png"</span><span class="p">,</span> <span class="nx">sizes</span><span class="o">:</span> <span class="s2">"128x128"</span><span class="p">,</span> <span class="nx">type</span><span class="o">:</span> <span class="s2">"image/png"</span><span class="p">},</span>
+    <span class="p">{</span><span class="nx">src</span><span class="o">:</span> <span class="s2">"podcast_hd.png"</span><span class="p">,</span> <span class="nx">sizes</span><span class="o">:</span> <span class="s2">"256x256"</span><span class="p">,</span> <span class="nx">type</span><span class="o">:</span> <span class="s2">"image/png"</span><span class="p">},</span>
+    <span class="p">{</span><span class="nx">src</span><span class="o">:</span> <span class="s2">"podcast.ico"</span><span class="p">,</span> <span class="nx">sizes</span><span class="o">:</span> <span class="s2">"128x128 256x256"</span><span class="p">,</span> <span class="nx">type</span><span class="o">:</span> <span class="s2">"image/x-icon"</span><span class="p">}</span>
+  <span class="p">]</span>
+<span class="p">});</span></pre>
+    <p>For example, if the user agent wants to use an image as icon, it may choose <code>"podcast.jpg"</code> or <code>"podcast.png"</code> for a
+  low-pixel-density screen, and <code>"podcast_hd.jpg"</code> or <code>"podcast_hd.png"</code> for a high-pixel-density screen. If the user
+  agent want to use an image for lockscreen background, <code>"podcast_xhd.jpg"</code> will be prefered.</p>
    </div>
-   <div class="example" id="example-23955676">
-    <a class="self-link" href="#example-23955676"></a> For playlists or chapters of an audio book, multiple <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media elements</a> can
+   <div class="example" id="example-e84dc250">
+    <a class="self-link" href="#example-e84dc250"></a> For playlists or chapters of an audio book, multiple <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media elements</a> can
   share a single <a data-link-type="dfn" href="#media-session">media session</a>. 
 <pre class="lang-javascript highlight"><span></span><span class="kd">var</span> <span class="nx">audio1</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">createElement</span><span class="p">(</span><span class="s2">"audio"</span><span class="p">);</span>
 <span class="nx">audio1</span><span class="p">.</span><span class="nx">src</span> <span class="o">=</span> <span class="s2">"chapter1.mp3"</span><span class="p">;</span>
@@ -1030,9 +1047,7 @@ media session from an <code class="idl"><a data-link-type="idl" href="https://we
     <span class="nx">title</span><span class="o">:</span> <span class="nx">event</span><span class="p">.</span><span class="nx">target</span> <span class="o">==</span> <span class="nx">audio1</span> <span class="o">?</span> <span class="s2">"Chapter 1"</span> <span class="o">:</span> <span class="s2">"Chapter 2"</span><span class="p">,</span>
     <span class="nx">artist</span><span class="o">:</span> <span class="s2">"An Author"</span><span class="p">,</span>
     <span class="nx">album</span><span class="o">:</span> <span class="s2">"A Book"</span><span class="p">,</span>
-    <span class="nx">artworks</span><span class="o">:</span> <span class="p">{</span>
-      <span class="nx">src</span><span class="o">:</span> <span class="s2">"cover.jpg"</span>
-    <span class="p">}</span>
+    <span class="nx">artworks</span><span class="o">:</span> <span class="p">[{</span><span class="nx">src</span><span class="o">:</span> <span class="s2">"cover.jpg"</span><span class="p">}]</span>
   <span class="p">});</span>
 <span class="p">}</span>
 
@@ -1093,11 +1108,11 @@ neighboring rights to this work.</p>
      <li><a href="#mediametadata-artist">dfn for MediaMetadata</a><span>, in §5</span>
      <li><a href="#dom-mediametadata-artist">attribute for MediaMetadata</a><span>, in §5</span>
     </ul>
-   <li><a href="#mediametadata-artwork">artwork</a><span>, in §5</span>
    <li>
     artworks
     <ul>
      <li><a href="#dom-mediametadatainit-artworks">dict-member for MediaMetadataInit</a><span>, in §5</span>
+     <li><a href="#mediametadata-artworks">dfn for MediaMetadata</a><span>, in §5</span>
      <li><a href="#dom-mediametadata-artworks">attribute for MediaMetadata</a><span>, in §5</span>
     </ul>
    <li><a href="#audio-producing-object">audio-producing object</a><span>, in §4.3</span>
@@ -1306,14 +1321,14 @@ interface <a href="#mediametadata">MediaMetadata</a> {
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-title">title</a>;
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-artist">artist</a>;
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-album">album</a>;
-  readonly attribute sequence&lt;<a data-link-type="idl-name" href="#mediaartwork">MediaArtwork</a>> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="sequence<MediaArtwork>" href="#dom-mediametadata-artworks">artworks</a>;
+  readonly attribute FrozenArray&lt;<a data-link-type="idl-name" href="#mediaartwork">MediaArtwork</a>> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="FrozenArray<MediaArtwork>" href="#dom-mediametadata-artworks">artworks</a>;
 };
 
 dictionary <a href="#dictdef-mediametadatainit">MediaMetadataInit</a> {
   DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediametadatainit-title">title</a> = "";
   DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediametadatainit-artist">artist</a> = "";
   DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediametadatainit-album">album</a> = "";
-  sequence&lt;<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a>>? <a data-type="sequence<MediaArtworkInit>? " href="#dom-mediametadatainit-artworks">artworks</a>;
+  sequence&lt;<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a>> <a data-default="None" data-type="sequence<MediaArtworkInit> " href="#dom-mediametadatainit-artworks">artworks</a> = [];
 };
 
 [<a href="#dom-mediaartwork-mediaartwork">Constructor</a>(<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a> <a href="#dom-mediaartwork-mediaartwork-init-init">init</a>)]

--- a/mediasession.html
+++ b/mediasession.html
@@ -264,23 +264,24 @@ notification areas and on lock screens of mobile devices.</p>
       <li><a href="#deactivating-a-media-session"><span class="secno">4.6</span> <span class="content">Deactivating a media session</span></a>
      </ol>
     <li><a href="#the-mediametadata-interface"><span class="secno">5</span> <span class="content">The <code class="idl"><span>MediaMetadata</span></code> interface</span></a>
+    <li><a href="#the-mediaartwork-interface"><span class="secno">6</span> <span class="content">The <code class="idl"><span>MediaArtwork</span></code> interface</span></a>
     <li>
-     <a href="#extensions-to-the-htmlmediaelement-interface"><span class="secno">6</span> <span class="content">Extensions to the <code class="idl"><span>HTMLMediaElement</span></code> interface</span></a>
+     <a href="#extensions-to-the-htmlmediaelement-interface"><span class="secno">7</span> <span class="content">Extensions to the <code class="idl"><span>HTMLMediaElement</span></code> interface</span></a>
      <ol class="toc">
-      <li><a href="#activating-a-media-session-from-an-htmlmediaelement-object"><span class="secno">6.1</span> <span class="content">Activating a
+      <li><a href="#activating-a-media-session-from-an-htmlmediaelement-object"><span class="secno">7.1</span> <span class="content">Activating a
 media session from an <code class="idl"><span>HTMLMediaElement</span></code> object</span></a>
-      <li><a href="#interrupting-a-media-session-from-an-htmlmediaelement-object"><span class="secno">6.2</span> <span class="content">Interrupting a
+      <li><a href="#interrupting-a-media-session-from-an-htmlmediaelement-object"><span class="secno">7.2</span> <span class="content">Interrupting a
 media session from an <code class="idl"><span>HTMLMediaElement</span></code> object</span></a>
-      <li><a href="#deactivating-a-media-session-from-an-htmlmediaelement-object"><span class="secno">6.3</span> <span class="content">Deactivating a
+      <li><a href="#deactivating-a-media-session-from-an-htmlmediaelement-object"><span class="secno">7.3</span> <span class="content">Deactivating a
 media session from an <code class="idl"><span>HTMLMediaElement</span></code> object</span></a>
      </ol>
     <li>
-     <a href="#extensions-to-the-audiocontext-interface"><span class="secno">7</span> <span class="content">Extensions to the <code class="idl"><span>AudioContext</span></code> interface</span></a>
+     <a href="#extensions-to-the-audiocontext-interface"><span class="secno">8</span> <span class="content">Extensions to the <code class="idl"><span>AudioContext</span></code> interface</span></a>
      <ol class="toc">
-      <li><a href="#interrupting-a-media-session-from-an-audiocontext-object"><span class="secno">7.1</span> <span class="content">Interrupting a
+      <li><a href="#interrupting-a-media-session-from-an-audiocontext-object"><span class="secno">8.1</span> <span class="content">Interrupting a
 media session from an <code class="idl"><span>AudioContext</span></code> object</span></a>
      </ol>
-    <li><a href="#examples"><span class="secno">8</span> <span class="content">Examples</span></a>
+    <li><a href="#examples"><span class="secno">9</span> <span class="content">Examples</span></a>
     <li><a href="#acknowledgments"><span class="secno"></span> <span class="content">Acknowledgments</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
@@ -395,7 +396,11 @@ which is either a <code class="idl"><a data-link-type="idl" href="#mediametadata
    <p>The <dfn class="idl-code" data-dfn-for="MediaSession" data-dfn-type="constructor" data-export="" id="dom-mediasession-mediasession"><code>MediaSession(<var>kind</var>)</code><a class="self-link" href="#dom-mediasession-mediasession"></a></dfn> constructor, when invoked, must return a new <a data-link-type="dfn" href="#media-session">media session</a> whose <a data-link-type="dfn" href="#mediasession-kind">kind</a> is <var>kind</var>, and <a data-link-type="dfn" href="#mediasession-state">state</a> is <code><a data-link-type="dfn" href="#idle-media-session-state">idle</a></code>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MediaSession" data-dfn-type="attribute" data-export="" id="dom-mediasession-kind"><code>kind</code><a class="self-link" href="#dom-mediasession-kind"></a></dfn> attribute must return the <a data-link-type="dfn" href="#media-session">media session</a>’s <a data-link-type="dfn" href="#mediasession-kind">kind</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MediaSession" data-dfn-type="attribute" data-export="" id="dom-mediasession-metadata"><code>metadata</code><a class="self-link" href="#dom-mediasession-metadata"></a></dfn> attribute, on
-getting, must return the <a data-link-type="dfn" href="#media-session">media session</a>’s <a data-link-type="dfn" href="#media-session-metadata">metadata</a>. On setting, the <a data-link-type="dfn" href="#media-session">media session</a>’s <a data-link-type="dfn" href="#media-session-metadata">metadata</a> must be set to the new value.</p>
+getting, must return the <a data-link-type="dfn" href="#media-session">media session</a>’s <a data-link-type="dfn" href="#media-session-metadata">metadata</a>. On setting, the user agent must run the following steps:</p>
+   <ol>
+    <li> Set the <a data-link-type="dfn" href="#media-session">media session</a>’s <a data-link-type="dfn" href="#media-session-metadata">metadata</a> to the new value. 
+    <li> Run the <a data-link-type="dfn" href="#fetch-steps">fetch steps</a> for <a data-link-type="dfn" href="#media-session">media session</a>’s <a data-link-type="dfn" href="#media-session-metadata">metadata</a>. 
+   </ol>
    <p>The <dfn class="idl-code" data-dfn-for="MediaSession" data-dfn-type="method" data-export="" id="dom-mediasession-activate"><code>activate()</code><a class="self-link" href="#dom-mediasession-activate"></a></dfn> method, when
 invoked, must run these steps:</p>
    <ol>
@@ -809,25 +814,96 @@ the following steps:</p>
    <h2 class="heading settled" data-level="5" id="the-mediametadata-interface"><span class="secno">5. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> interface</span><a class="self-link" href="#the-mediametadata-interface"></a></h2>
 <pre class="idl def">[<a class="idl-code" data-link-type="constructor" href="#dom-mediametadata-mediametadata">Constructor</a>(<a data-link-type="idl-name" href="#dictdef-mediametadatainit">MediaMetadataInit</a> <dfn class="idl-code" data-dfn-for="MediaMetadata/MediaMetadata(init)" data-dfn-type="argument" data-export="" id="dom-mediametadata-mediametadata-init-init">init<a class="self-link" href="#dom-mediametadata-mediametadata-init-init"></a></dfn>)]
 interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="mediametadata">MediaMetadata<a class="self-link" href="#mediametadata"></a></dfn> {
-  readonly attribute DOMString <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-mediametadata-title">title<a class="self-link" href="#dom-mediametadata-title"></a></dfn>;
-  readonly attribute DOMString <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-mediametadata-artist">artist<a class="self-link" href="#dom-mediametadata-artist"></a></dfn>;
-  readonly attribute DOMString <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-mediametadata-album">album<a class="self-link" href="#dom-mediametadata-album"></a></dfn>;
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-title">title</a>;
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-artist">artist</a>;
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-album">album</a>;
+  readonly attribute sequence&lt;<a data-link-type="idl-name" href="#mediaartwork">MediaArtwork</a>> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="sequence<MediaArtwork>" href="#dom-mediametadata-artworks">artworks</a>;
 };
 
 dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-mediametadatainit">MediaMetadataInit<a class="self-link" href="#dictdef-mediametadatainit"></a></dfn> {
   DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediametadatainit-title">title<a class="self-link" href="#dom-mediametadatainit-title"></a></dfn> = "";
   DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediametadatainit-artist">artist<a class="self-link" href="#dom-mediametadatainit-artist"></a></dfn> = "";
   DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediametadatainit-album">album<a class="self-link" href="#dom-mediametadatainit-album"></a></dfn> = "";
+  sequence&lt;<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a>>? <dfn class="idl-code" data-dfn-for="MediaMetadataInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MediaArtworkInit>? " id="dom-mediametadatainit-artworks">artworks<a class="self-link" href="#dom-mediametadatainit-artworks"></a></dfn>;
 };
 </pre>
+   <p>A <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> object has a <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-title">title<a class="self-link" href="#mediametadata-title"></a></dfn>, an <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-artist">artist<a class="self-link" href="#mediametadata-artist"></a></dfn>, an <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-album">album<a class="self-link" href="#mediametadata-album"></a></dfn> and a
+sequence of <dfn data-dfn-for="MediaMetadata" data-dfn-type="dfn" data-noexport="" id="mediametadata-artwork">artwork<a class="self-link" href="#mediametadata-artwork"></a></dfn>s.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="constructor" data-export="" id="dom-mediametadata-mediametadata"><code>MediaMetadata(<var>init</var>)</code><a class="self-link" href="#dom-mediametadata-mediametadata"></a></dfn> constructor, when invoked, must run the following steps:</p>
    <ol>
     <li> Let <var>metadata</var> be a new <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> object. 
-    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-title">title</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-artist">artist</a></code>,
-    and <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-album">album</a></code> attributes to the values of <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-title">title</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-artist">artist</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-album">album</a></code> members, respectively. 
+    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-title">title</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-title">title</a></code>. 
+    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-artist">artist</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-artist">artist</a></code>. 
+    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-album">album</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-album">album</a></code>. 
+    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadata-artworks">artworks</a></code> using <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediametadatainit-artworks">artworks</a></code> by calling the <a data-link-type="functionish" href="#dom-mediaartwork-mediaartwork"><code>MediaArtwork(init)</code></a> constructor. 
     <li> Return <var>metadata</var>. 
    </ol>
-   <h2 class="heading settled" data-level="6" id="extensions-to-the-htmlmediaelement-interface"><span class="secno">6. </span><span class="content">Extensions to the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a></code> interface</span><a class="self-link" href="#extensions-to-the-htmlmediaelement-interface"></a></h2>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" id="dom-mediametadata-title"><code>title</code><a class="self-link" href="#dom-mediametadata-title"></a></dfn> attribute must
+return the <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> objects’s <a data-link-type="dfn" href="#mediametadata-title">title</a>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" id="dom-mediametadata-artist"><code>artist</code><a class="self-link" href="#dom-mediametadata-artist"></a></dfn> attribute must
+return the <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> objects’s <a data-link-type="dfn" href="#mediametadata-artist">artist</a>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" id="dom-mediametadata-album"><code>album</code><a class="self-link" href="#dom-mediametadata-album"></a></dfn> attribute must
+return the <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> objects’s <a data-link-type="dfn" href="#mediametadata-album">album</a>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaMetadata" data-dfn-type="attribute" data-export="" id="dom-mediametadata-artworks"><code>artworks</code><a class="self-link" href="#dom-mediametadata-artworks"></a></dfn> attribute
+must return the <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> objects’s <a data-link-type="dfn" href="#mediametadata-artwork">artwork</a>s, as a sequence of <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code>s. The <a class="idl-code" data-link-type="attribute" href="#dom-mediametadata-artworks">artworks</a> attribute
+can be empty.</p>
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="fetch-steps">fetch steps<a class="self-link" href="#fetch-steps"></a></dfn> for a given <code class="idl"><a data-link-type="idl" href="#mediametadata">MediaMetadata</a></code> object <var>metadata</var> are:</p>
+   <ol>
+    <li> If <var>metadata</var>’s <a data-link-type="dfn" href="#mediametadata-artwork"><code>artworks</code></a> is empty, then
+    terminate these steps. 
+    <li> If the platform supports displaying media artwork, select a <dfn data-dfn-type="dfn" data-noexport="" id="prefered-artwork">prefered
+    artwork<a class="self-link" href="#prefered-artwork"></a></dfn> from <var>metadata</var>’s <a data-link-type="dfn" href="#mediametadata-artwork"><code>artworks</code></a>. 
+    <li>
+      <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> <a data-link-type="dfn" href="#prefered-artwork">prefered artwork</a>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-src">src</a></code>. 
+     <p>Then, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+     <ol>
+      <li> Wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>. 
+      <li> If the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-internal-response">internal response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type">type</a> is <i>default</i>, attempt to decode the
+        resource as image. 
+      <li> If the image format is supported, use the image as the artwork for
+        display. (Otherwise the user agent can select another <a data-link-type="dfn" href="#prefered-artwork">prefered
+        artwork</a> and try again.) 
+     </ol>
+   </ol>
+   <h2 class="heading settled" data-level="6" id="the-mediaartwork-interface"><span class="secno">6. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> interface</span><a class="self-link" href="#the-mediaartwork-interface"></a></h2>
+<pre class="idl def">[<dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="constructor" data-export="" data-lt="MediaArtwork(init)" id="dom-mediaartwork-mediaartwork">Constructor<a class="self-link" href="#dom-mediaartwork-mediaartwork"></a></dfn>(<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a> <dfn class="idl-code" data-dfn-for="MediaArtwork/MediaArtwork(init)" data-dfn-type="argument" data-export="" id="dom-mediaartwork-mediaartwork-init-init">init<a class="self-link" href="#dom-mediaartwork-mediaartwork-init-init"></a></dfn>)]
+interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="mediaartwork">MediaArtwork<a class="self-link" href="#mediaartwork"></a></dfn> {
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-src">src</a>;
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-sizes">sizes</a>;
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-type">type</a>;
+};
+
+dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-mediaartworkinit">MediaArtworkInit<a class="self-link" href="#dictdef-mediaartworkinit"></a></dfn> {
+  DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaArtworkInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediaartworkinit-src">src<a class="self-link" href="#dom-mediaartworkinit-src"></a></dfn> = "";
+  DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaArtworkInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediaartworkinit-sizes">sizes<a class="self-link" href="#dom-mediaartworkinit-sizes"></a></dfn> = "";
+  DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="MediaArtworkInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-mediaartworkinit-type">type<a class="self-link" href="#dom-mediaartworkinit-type"></a></dfn> = "";
+};
+</pre>
+   <p>A <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object has a <dfn data-dfn-for="MediaArtwork" data-dfn-type="dfn" data-noexport="" id="mediaartwork-source">source<a class="self-link" href="#mediaartwork-source"></a></dfn>, a list of <dfn data-dfn-for="MediaArtwork" data-dfn-type="dfn" data-noexport="" id="mediaartwork-sizes">sizes<a class="self-link" href="#mediaartwork-sizes"></a></dfn>, and a <dfn data-dfn-for="MediaArtwork" data-dfn-type="dfn" data-noexport="" id="mediaartwork-type">type<a class="self-link" href="#mediaartwork-type"></a></dfn>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="constructor" data-export="" id="dom-mediaartwork-mediametadata"><code>MediaMetadata(<var>init</var>)</code><a class="self-link" href="#dom-mediaartwork-mediametadata"></a></dfn> constructor, when invoked, must run the following steps:</p>
+   <ol>
+    <li> Let <var>metadata</var> be a new <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object. 
+    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-src">src</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartworkinit-src">src</a></code>. 
+    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-sizes">sizes</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartworkinit-sizes">sizes</a></code>. 
+    <li> Set <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartwork-type">type</a></code> to <var>init</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mediaartworkinit-type">type</a></code>. 
+    <li> Return <var>metadata</var>. 
+   </ol>
+   <p>The MediaArtwork <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-src">src</a>, <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-sizes">sizes</a> and <a class="idl-code" data-link-type="attribute" href="#dom-mediaartwork-type">type</a> conforms to the <a data-link-type="dfn" href="http://www.w3.org/TR/appmanifest/#dfn-image-object">image object</a>s in Web App Manifest.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="attribute" data-export="" id="dom-mediaartwork-src">src<a class="self-link" href="#dom-mediaartwork-src"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object’s <a data-link-type="dfn" href="#mediaartwork-source">source</a>. It is a URL from
+which the user agent can fetch the image’s data.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="attribute" data-export="" id="dom-mediaartwork-sizes">sizes<a class="self-link" href="#dom-mediaartwork-sizes"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object’s <a data-link-type="dfn" href="#mediaartwork-sizes">sizes</a>. It is a string
+consisting of an unordered set of unique space-separated tokens which are AScII
+case insensitive that represents the dimensions of an image. Each keyword is
+either an ASCII case-insensitive match for the string "any", or a value that
+consists of two valid non-negative integers that do not have a leading U+0030
+DIGIT ZERO (0) character and that are separated by a single U+0078 LATIN SMALL
+LETTER X or U+0058 LATIN CAPITAL LETTER X character. The keywords represent icon
+sizes in raw pixels (as opposed to CSS pixels). When multiple image objects are
+available, a user agent may use the value to decide which icon is most suitable
+for a display context (and ignore any that are inappropriate).</p>
+   <p>The <dfn class="idl-code" data-dfn-for="MediaArtwork" data-dfn-type="attribute" data-export="" id="dom-mediaartwork-type">type<a class="self-link" href="#dom-mediaartwork-type"></a></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#mediaartwork">MediaArtwork</a></code> object’s <a data-link-type="dfn" href="#mediaartwork-type">type</a>. It is a MIME type for
+deciding the media type of the image.</p>
+   <h2 class="heading settled" data-level="7" id="extensions-to-the-htmlmediaelement-interface"><span class="secno">7. </span><span class="content">Extensions to the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a></code> interface</span><a class="self-link" href="#extensions-to-the-htmlmediaelement-interface"></a></h2>
 <pre class="idl def">partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a> {
   attribute <a data-link-type="idl-name" href="#mediasession">MediaSession</a>? <a class="idl-code" data-link-type="attribute" data-type="MediaSession?" href="#dom-htmlmediaelement-session">session</a>;
 };
@@ -849,7 +925,7 @@ otherwise. On setting, the user agent must run the following steps:</p>
     <li> Set the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media elements</a>’s <a data-link-type="dfn" href="#current-media-session">current media session</a> to the new
     value. 
    </ol>
-   <h3 class="heading settled" data-level="6.1" id="activating-a-media-session-from-an-htmlmediaelement-object"><span class="secno">6.1. </span><span class="content">Activating a
+   <h3 class="heading settled" data-level="7.1" id="activating-a-media-session-from-an-htmlmediaelement-object"><span class="secno">7.1. </span><span class="content">Activating a
 media session from an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a></code> object</span><a class="self-link" href="#activating-a-media-session-from-an-htmlmediaelement-object"></a></h3>
    <p>When the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-play">play()</a></code> method on a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> is invoked from script –
 or a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> is otherwise played from the web page (e.g. via its <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-media-controls">controls</a></code>) – and that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-paused">paused</a></code> attribute is true
@@ -863,19 +939,19 @@ following steps, passing in <a data-link-type="dfn" href="https://html.spec.what
     <li> <a data-link-type="dfn" href="#activate">Activate</a> <var>media session</var>. 
     <li> If <a data-link-type="dfn" href="#activate">activate</a> failed, <a data-link-type="dfn" href="#pause">pause</a> <var>media element</var>. 
    </ol>
-   <h3 class="heading settled" data-level="6.2" id="interrupting-a-media-session-from-an-htmlmediaelement-object"><span class="secno">6.2. </span><span class="content">Interrupting a
+   <h3 class="heading settled" data-level="7.2" id="interrupting-a-media-session-from-an-htmlmediaelement-object"><span class="secno">7.2. </span><span class="content">Interrupting a
 media session from an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a></code> object</span><a class="self-link" href="#interrupting-a-media-session-from-an-htmlmediaelement-object"></a></h3>
    <p>When the user agent is to <dfn data-dfn-type="dfn" data-noexport="" id="pause-a-media-element">pause a media element<a class="self-link" href="#pause-a-media-element"></a></dfn> for a given <var>media element</var> it must run that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#internal-pause-steps">internal
 pause steps</a>.</p>
    <p>When the user agent is to <dfn data-dfn-type="dfn" data-noexport="" id="unpause-a-media-element">unpause a media element<a class="self-link" href="#unpause-a-media-element"></a></dfn> for a given <var>media element</var> it must invoke that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-play">play()</a></code> method.</p>
-   <h3 class="heading settled" data-level="6.3" id="deactivating-a-media-session-from-an-htmlmediaelement-object"><span class="secno">6.3. </span><span class="content">Deactivating a
+   <h3 class="heading settled" data-level="7.3" id="deactivating-a-media-session-from-an-htmlmediaelement-object"><span class="secno">7.3. </span><span class="content">Deactivating a
 media session from an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a></code> object</span><a class="self-link" href="#deactivating-a-media-session-from-an-htmlmediaelement-object"></a></h3>
    <p>When a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#ended-playback">playback has ended</a>, the
 user agent must <a data-link-type="dfn" href="#release-media-element-from-its-media-session">release media element from its media session</a>.</p>
    <p>Any time a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element-load-algorithm">load
 algorithm</a> is run by the user agent, it must <a data-link-type="dfn" href="#release-media-element-from-its-media-session">release media element from
 its media session</a>.</p>
-   <p>When the user agent is to <dfn data-dfn-type="dfn" data-lt="release media element from its media session" data-noexport="" id="release-media-element-from-its-media-session">release media element from its media
+   <p>When the user agent is to <dfn data-dfn-type="dfn" data-noexport="" id="release-media-element-from-its-media-session">release media element from its media
 session<a class="self-link" href="#release-media-element-from-its-media-session"></a></dfn> for a given <var>media element</var> it must run the following
 steps:</p>
    <ol>
@@ -888,7 +964,7 @@ steps:</p>
     <li> Run the <a data-link-type="dfn" href="#media-session-deactivation-algorithm">media session deactivation algorithm</a> for <var>media
     session</var>. 
    </ol>
-   <h2 class="heading settled" data-level="7" id="extensions-to-the-audiocontext-interface"><span class="secno">7. </span><span class="content">Extensions to the <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#audiocontext">AudioContext</a></code> interface</span><a class="self-link" href="#extensions-to-the-audiocontext-interface"></a></h2>
+   <h2 class="heading settled" data-level="8" id="extensions-to-the-audiocontext-interface"><span class="secno">8. </span><span class="content">Extensions to the <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#audiocontext">AudioContext</a></code> interface</span><a class="self-link" href="#extensions-to-the-audiocontext-interface"></a></h2>
 <pre class="idl def">partial interface <a class="idl-code" data-link-type="interface" href="https://webaudio.github.io/web-audio-api/#audiocontext">AudioContext</a> {
   attribute <a data-link-type="idl-name" href="#mediasession">MediaSession</a>? <a class="idl-code" data-link-type="attribute" data-type="MediaSession?" href="#dom-audiocontext-session">session</a>;
 };
@@ -909,14 +985,14 @@ agent must run the following steps:</p>
     <li> Set the <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#audiocontext">AudioContext</a></code> object’s <a data-link-type="dfn" href="#current-media-session">current media session</a> to the new
     value. 
    </ol>
-   <h3 class="heading settled" data-level="7.1" id="interrupting-a-media-session-from-an-audiocontext-object"><span class="secno">7.1. </span><span class="content">Interrupting a
+   <h3 class="heading settled" data-level="8.1" id="interrupting-a-media-session-from-an-audiocontext-object"><span class="secno">8.1. </span><span class="content">Interrupting a
 media session from an <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#audiocontext">AudioContext</a></code> object</span><a class="self-link" href="#interrupting-a-media-session-from-an-audiocontext-object"></a></h3>
    <p>When the user agent is to <dfn data-dfn-type="dfn" data-noexport="" id="suspend-a-web-audio-object">suspend a web audio object<a class="self-link" href="#suspend-a-web-audio-object"></a></dfn> for a given <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#audiocontext">AudioContext</a></code> object it must invoke that <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#audiocontext">AudioContext</a></code> object’s <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#widl-AudioContext-suspend-Promise-void">suspend()</a></code> method.</p>
    <p>When the user agent is to <dfn data-dfn-type="dfn" data-noexport="" id="resume-a-web-audio-object">resume a web audio object<a class="self-link" href="#resume-a-web-audio-object"></a></dfn> for a given <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#audiocontext">AudioContext</a></code> object it must invoke that <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#audiocontext">AudioContext</a></code> object’s <code class="idl"><a data-link-type="idl" href="https://webaudio.github.io/web-audio-api/#widl-AudioContext-resume-Promise-void">resume()</a></code> method.</p>
-   <h2 class="heading settled" data-level="8" id="examples"><span class="secno">8. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
+   <h2 class="heading settled" data-level="9" id="examples"><span class="secno">9. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
    <p><em>This section is non-normative.</em></p>
-   <div class="example" id="example-f6369591">
-    <a class="self-link" href="#example-f6369591"></a> For music or podcasts, using a <a data-link-type="dfn" href="#media-session">media session</a> of <a data-link-type="dfn" href="#mediasession-kind">kind</a> "<code><a data-link-type="dfn" href="#content">content</a></code>" can be appropriate. 
+   <div class="example" id="example-6fbc8af3">
+    <a class="self-link" href="#example-6fbc8af3"></a> For music or podcasts, using a <a data-link-type="dfn" href="#media-session">media session</a> of <a data-link-type="dfn" href="#mediasession-kind">kind</a> "<code><a data-link-type="dfn" href="#content">content</a></code>" can be appropriate. 
 <pre class="lang-javascript highlight"><span></span><span class="kd">var</span> <span class="nx">audio</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">createElement</span><span class="p">(</span><span class="s2">"audio"</span><span class="p">);</span>
 <span class="nx">audio</span><span class="p">.</span><span class="nx">src</span> <span class="o">=</span> <span class="s2">"podcast.mp3"</span><span class="p">;</span>
 <span class="nx">audio</span><span class="p">.</span><span class="nx">session</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">MediaSession</span><span class="p">();</span> <span class="c1">// "content" is the default kind</span>
@@ -926,10 +1002,13 @@ media session from an <code class="idl"><a data-link-type="idl" href="https://we
   <span class="nx">title</span><span class="o">:</span> <span class="s2">"Episode Title"</span><span class="p">,</span>
   <span class="nx">artist</span><span class="o">:</span> <span class="s2">"Podcast Host"</span><span class="p">,</span>
   <span class="nx">album</span><span class="o">:</span> <span class="s2">"Podcast Title"</span><span class="p">,</span>
+  <span class="nx">artworks</span><span class="o">:</span> <span class="p">{</span>
+    <span class="nx">src</span><span class="o">:</span><span class="s2">"podcast.jpg"</span>
+  <span class="p">}</span>
 <span class="p">});</span></pre>
    </div>
-   <div class="example" id="example-24a01ca6">
-    <a class="self-link" href="#example-24a01ca6"></a> For playlists or chapters of an audio book, multiple <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media elements</a> can
+   <div class="example" id="example-23955676">
+    <a class="self-link" href="#example-23955676"></a> For playlists or chapters of an audio book, multiple <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media elements</a> can
   share a single <a data-link-type="dfn" href="#media-session">media session</a>. 
 <pre class="lang-javascript highlight"><span></span><span class="kd">var</span> <span class="nx">audio1</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">createElement</span><span class="p">(</span><span class="s2">"audio"</span><span class="p">);</span>
 <span class="nx">audio1</span><span class="p">.</span><span class="nx">src</span> <span class="o">=</span> <span class="s2">"chapter1.mp3"</span><span class="p">;</span>
@@ -951,6 +1030,9 @@ media session from an <code class="idl"><a data-link-type="idl" href="https://we
     <span class="nx">title</span><span class="o">:</span> <span class="nx">event</span><span class="p">.</span><span class="nx">target</span> <span class="o">==</span> <span class="nx">audio1</span> <span class="o">?</span> <span class="s2">"Chapter 1"</span> <span class="o">:</span> <span class="s2">"Chapter 2"</span><span class="p">,</span>
     <span class="nx">artist</span><span class="o">:</span> <span class="s2">"An Author"</span><span class="p">,</span>
     <span class="nx">album</span><span class="o">:</span> <span class="s2">"A Book"</span><span class="p">,</span>
+    <span class="nx">artworks</span><span class="o">:</span> <span class="p">{</span>
+      <span class="nx">src</span><span class="o">:</span> <span class="s2">"cover.jpg"</span>
+    <span class="p">}</span>
   <span class="p">});</span>
 <span class="p">}</span>
 
@@ -993,8 +1075,9 @@ neighboring rights to this work.</p>
    <li>
     album
     <ul>
-     <li><a href="#dom-mediametadata-album">attribute for MediaMetadata</a><span>, in §5</span>
      <li><a href="#dom-mediametadatainit-album">dict-member for MediaMetadataInit</a><span>, in §5</span>
+     <li><a href="#mediametadata-album">dfn for MediaMetadata</a><span>, in §5</span>
+     <li><a href="#dom-mediametadata-album">attribute for MediaMetadata</a><span>, in §5</span>
     </ul>
    <li><a href="#dom-mediasessionkind-ambient">"ambient"</a><span>, in §4</span>
    <li>
@@ -1006,8 +1089,16 @@ neighboring rights to this work.</p>
    <li>
     artist
     <ul>
-     <li><a href="#dom-mediametadata-artist">attribute for MediaMetadata</a><span>, in §5</span>
      <li><a href="#dom-mediametadatainit-artist">dict-member for MediaMetadataInit</a><span>, in §5</span>
+     <li><a href="#mediametadata-artist">dfn for MediaMetadata</a><span>, in §5</span>
+     <li><a href="#dom-mediametadata-artist">attribute for MediaMetadata</a><span>, in §5</span>
+    </ul>
+   <li><a href="#mediametadata-artwork">artwork</a><span>, in §5</span>
+   <li>
+    artworks
+    <ul>
+     <li><a href="#dom-mediametadatainit-artworks">dict-member for MediaMetadataInit</a><span>, in §5</span>
+     <li><a href="#dom-mediametadata-artworks">attribute for MediaMetadata</a><span>, in §5</span>
     </ul>
    <li><a href="#audio-producing-object">audio-producing object</a><span>, in §4.3</span>
    <li><a href="#audio-producing-participants">audio-producing participants</a><span>, in §4.3</span>
@@ -1022,6 +1113,7 @@ neighboring rights to this work.</p>
    <li><a href="#deactivate">deactivate</a><span>, in §4.6</span>
    <li><a href="#dom-mediasession-deactivate">deactivate()</a><span>, in §4</span>
    <li><a href="#duck">duck</a><span>, in §4.3</span>
+   <li><a href="#fetch-steps">fetch steps</a><span>, in §5</span>
    <li><a href="#idle-media-session-state">idle media session state</a><span>, in §4.1</span>
    <li><a href="#indefinitely-pause">indefinitely pause</a><span>, in §4.3</span>
    <li><a href="#interrupted-media-session-state">interrupted media session state</a><span>, in §4.1</span>
@@ -1031,8 +1123,16 @@ neighboring rights to this work.</p>
      <li><a href="#dom-mediasession-kind">attribute for MediaSession</a><span>, in §4</span>
      <li><a href="#mediasession-kind">dfn for MediaSession</a><span>, in §4.2</span>
     </ul>
+   <li><a href="#mediaartwork">MediaArtwork</a><span>, in §6</span>
+   <li><a href="#dictdef-mediaartworkinit">MediaArtworkInit</a><span>, in §6</span>
+   <li><a href="#dom-mediaartwork-mediaartwork">MediaArtwork(init)</a><span>, in §6</span>
    <li><a href="#mediametadata">MediaMetadata</a><span>, in §5</span>
-   <li><a href="#dom-mediametadata-mediametadata">MediaMetadata(init)</a><span>, in §5</span>
+   <li>
+    MediaMetadata(init)
+    <ul>
+     <li><a href="#dom-mediametadata-mediametadata">constructor for MediaMetadata</a><span>, in §5</span>
+     <li><a href="#dom-mediaartwork-mediametadata">constructor for MediaArtwork</a><span>, in §6</span>
+    </ul>
    <li><a href="#dictdef-mediametadatainit">MediaMetadataInit</a><span>, in §5</span>
    <li><a href="#media-session">media session</a><span>, in §4</span>
    <li><a href="#mediasession">MediaSession</a><span>, in §4</span>
@@ -1044,23 +1144,41 @@ neighboring rights to this work.</p>
    <li><a href="#media-session-metadata">media session metadata</a><span>, in §4</span>
    <li><a href="#dom-mediasession-metadata">metadata</a><span>, in §4</span>
    <li><a href="#pause">pause</a><span>, in §4.3</span>
-   <li><a href="#pause-a-media-element">pause a media element</a><span>, in §6.2</span>
-   <li><a href="#release-media-element-from-its-media-session">release media element from its media session</a><span>, in §6.3</span>
-   <li><a href="#resume-a-web-audio-object">resume a web audio object</a><span>, in §7.1</span>
+   <li><a href="#pause-a-media-element">pause a media element</a><span>, in §7.2</span>
+   <li><a href="#prefered-artwork">prefered
+    artwork</a><span>, in §5</span>
+   <li><a href="#release-media-element-from-its-media-session">release media element from its media
+session</a><span>, in §7.3</span>
+   <li><a href="#resume-a-web-audio-object">resume a web audio object</a><span>, in §8.1</span>
    <li><a href="#resume-list">resume list</a><span>, in §4.3</span>
    <li>
     session
     <ul>
-     <li><a href="#dom-htmlmediaelement-session">attribute for HTMLMediaElement</a><span>, in §6</span>
-     <li><a href="#dom-audiocontext-session">attribute for AudioContext</a><span>, in §7</span>
+     <li><a href="#dom-htmlmediaelement-session">attribute for HTMLMediaElement</a><span>, in §7</span>
+     <li><a href="#dom-audiocontext-session">attribute for AudioContext</a><span>, in §8</span>
+    </ul>
+   <li>
+    sizes
+    <ul>
+     <li><a href="#dom-mediaartworkinit-sizes">dict-member for MediaArtworkInit</a><span>, in §6</span>
+     <li><a href="#mediaartwork-sizes">dfn for MediaArtwork</a><span>, in §6</span>
+     <li><a href="#dom-mediaartwork-sizes">attribute for MediaArtwork</a><span>, in §6</span>
+    </ul>
+   <li><a href="#mediaartwork-source">source</a><span>, in §6</span>
+   <li>
+    src
+    <ul>
+     <li><a href="#dom-mediaartworkinit-src">dict-member for MediaArtworkInit</a><span>, in §6</span>
+     <li><a href="#dom-mediaartwork-src">attribute for MediaArtwork</a><span>, in §6</span>
     </ul>
    <li><a href="#mediasession-state">state</a><span>, in §4.1</span>
-   <li><a href="#suspend-a-web-audio-object">suspend a web audio object</a><span>, in §7.1</span>
+   <li><a href="#suspend-a-web-audio-object">suspend a web audio object</a><span>, in §8.1</span>
    <li>
     title
     <ul>
-     <li><a href="#dom-mediametadata-title">attribute for MediaMetadata</a><span>, in §5</span>
      <li><a href="#dom-mediametadatainit-title">dict-member for MediaMetadataInit</a><span>, in §5</span>
+     <li><a href="#mediametadata-title">dfn for MediaMetadata</a><span>, in §5</span>
+     <li><a href="#dom-mediametadata-title">attribute for MediaMetadata</a><span>, in §5</span>
     </ul>
    <li><a href="#dom-mediasessionkind-transient">"transient"</a><span>, in §4</span>
    <li>
@@ -1076,12 +1194,27 @@ neighboring rights to this work.</p>
      <li><a href="#transient-solo">definition of</a><span>, in §4.2</span>
     </ul>
    <li><a href="#dom-mediasessionkind-transient-solo">"transient-solo"</a><span>, in §4</span>
+   <li>
+    type
+    <ul>
+     <li><a href="#dom-mediaartworkinit-type">dict-member for MediaArtworkInit</a><span>, in §6</span>
+     <li><a href="#mediaartwork-type">dfn for MediaArtwork</a><span>, in §6</span>
+     <li><a href="#dom-mediaartwork-type">attribute for MediaArtwork</a><span>, in §6</span>
+    </ul>
    <li><a href="#unduck">unduck</a><span>, in §4.3</span>
    <li><a href="#unpause">unpause</a><span>, in §4.3</span>
-   <li><a href="#unpause-a-media-element">unpause a media element</a><span>, in §6.2</span>
+   <li><a href="#unpause-a-media-element">unpause a media element</a><span>, in §7.2</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
+   <li>
+    <a data-link-type="biblio">[FETCH]</a> defines the following terms:
+    <ul>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-internal-response">internal response</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-response">response</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-response-type">response type</a>
+    </ul>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
@@ -1121,6 +1254,11 @@ neighboring rights to this work.</p>
      <li><a href="https://webaudio.github.io/web-audio-api/#widl-AudioContext-suspend-Promise-void">suspend()</a>
     </ul>
    <li>
+    <a data-link-type="biblio">[appmanifest]</a> defines the following terms:
+    <ul>
+     <li><a href="http://www.w3.org/TR/appmanifest/#dfn-image-object">image object</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[WHATWG-DOM]</a> defines the following terms:
     <ul>
      <li><a href="https://dom.spec.whatwg.org/#context-object">context object</a>
@@ -1129,6 +1267,10 @@ neighboring rights to this work.</p>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
+   <dt id="biblio-appmanifest">[APPMANIFEST]
+   <dd>Marcos Caceres; et al. <a href="https://w3c.github.io/manifest/">Web App Manifest</a>. 19 May 2016. WD. URL: <a href="https://w3c.github.io/manifest/">https://w3c.github.io/manifest/</a>
+   <dt id="biblio-fetch">[FETCH]
+   <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
    <dt id="biblio-html">[HTML]
    <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-page-visibility">[PAGE-VISIBILITY]
@@ -1161,15 +1303,30 @@ enum <a href="#enumdef-mediasessionkind">MediaSessionKind</a> {
 
 [<a class="idl-code" data-link-type="constructor" href="#dom-mediametadata-mediametadata">Constructor</a>(<a data-link-type="idl-name" href="#dictdef-mediametadatainit">MediaMetadataInit</a> <a href="#dom-mediametadata-mediametadata-init-init">init</a>)]
 interface <a href="#mediametadata">MediaMetadata</a> {
-  readonly attribute DOMString <a data-readonly="" data-type="DOMString" href="#dom-mediametadata-title">title</a>;
-  readonly attribute DOMString <a data-readonly="" data-type="DOMString" href="#dom-mediametadata-artist">artist</a>;
-  readonly attribute DOMString <a data-readonly="" data-type="DOMString" href="#dom-mediametadata-album">album</a>;
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-title">title</a>;
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-artist">artist</a>;
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediametadata-album">album</a>;
+  readonly attribute sequence&lt;<a data-link-type="idl-name" href="#mediaartwork">MediaArtwork</a>> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="sequence<MediaArtwork>" href="#dom-mediametadata-artworks">artworks</a>;
 };
 
 dictionary <a href="#dictdef-mediametadatainit">MediaMetadataInit</a> {
   DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediametadatainit-title">title</a> = "";
   DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediametadatainit-artist">artist</a> = "";
   DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediametadatainit-album">album</a> = "";
+  sequence&lt;<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a>>? <a data-type="sequence<MediaArtworkInit>? " href="#dom-mediametadatainit-artworks">artworks</a>;
+};
+
+[<a href="#dom-mediaartwork-mediaartwork">Constructor</a>(<a data-link-type="idl-name" href="#dictdef-mediaartworkinit">MediaArtworkInit</a> <a href="#dom-mediaartwork-mediaartwork-init-init">init</a>)]
+interface <a href="#mediaartwork">MediaArtwork</a> {
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-src">src</a>;
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-sizes">sizes</a>;
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-mediaartwork-type">type</a>;
+};
+
+dictionary <a href="#dictdef-mediaartworkinit">MediaArtworkInit</a> {
+  DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediaartworkinit-src">src</a> = "";
+  DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediaartworkinit-sizes">sizes</a> = "";
+  DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-mediaartworkinit-type">type</a> = "";
 };
 
 partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">HTMLMediaElement</a> {


### PR DESCRIPTION
Make the artwork spec more like WebApp manifest icons, which has `src`,
`type` and `sizes` fields. The texts are based on pull request #126 

Fixes #56 
