### PR TITLE
Add new skip-ad media session action

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -454,7 +454,7 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
           playback has a notion of playlist.
         </li>
         <li>
-          <dfn enum-value for=MediaSessionAction>skip_ad</dfn>: the action
+          <dfn enum-value for=MediaSessionAction>skip-ad</dfn>: the action
           intent is to skip the advertisement that is currently playing.
         </li>
       </ul>
@@ -639,7 +639,7 @@ enum MediaSessionAction {
   "seekforward",
   "previoustrack",
   "nexttrack",
-  "skip_ad",
+  "skip-ad",
 };
 
 callback MediaSessionActionHandler = void();

--- a/index.bs
+++ b/index.bs
@@ -453,6 +453,10 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
           to move to the playback to the next item in the playlist if the
           playback has a notion of playlist.
         </li>
+        <li>
+          <dfn enum-value for=MediaSessionAction>skip_ad</dfn>: the action
+          intent is to skip the advertisement that is currently playing.
+        </li>
       </ul>
     </p>
 
@@ -635,6 +639,7 @@ enum MediaSessionAction {
   "seekforward",
   "previoustrack",
   "nexttrack",
+  "skip_ad",
 };
 
 callback MediaSessionActionHandler = void();


### PR DESCRIPTION
This PR adds a "skip ad" media session action that may be used by media notification and [picture-in-picture window controls](https://github.com/WICG/picture-in-picture/pull/69#issuecomment-432516966
)

Note that one already exists in Android Media Session: https://developer.android.com/reference/kotlin/android/support/v4/media/session/MediaSessionCompat#ACTION_SKIP_AD

We may want to add support for media session actions feature detection. WDYT?

@mounirlamouri 